### PR TITLE
fix: implement phone number sync across checkout and catering routes

### DIFF
--- a/src/lib/profile-sync.ts
+++ b/src/lib/profile-sync.ts
@@ -1,0 +1,151 @@
+'use server';
+
+import { prisma, withRetry } from '@/lib/db-unified';
+import { logger } from '@/utils/logger';
+
+/**
+ * Syncs customer phone number to their profile
+ * This ensures phone numbers are consistent across all orders and the user profile
+ *
+ * @param userId - The user's ID (optional for guest checkouts)
+ * @param email - The customer's email (used to find profile if no userId)
+ * @param phone - The phone number to sync
+ * @returns Promise<boolean> - Success status
+ */
+export async function syncPhoneToProfile(
+  userId: string | null | undefined,
+  email: string,
+  phone: string
+): Promise<boolean> {
+  try {
+    // Validate phone number
+    if (!phone || phone.trim().length === 0) {
+      logger.warn('[PROFILE-SYNC] No phone number provided, skipping sync');
+      return false;
+    }
+
+    const trimmedPhone = phone.trim();
+
+    // Find the profile by userId or email
+    const profile = await withRetry(async () => {
+      if (userId) {
+        return await prisma.profile.findUnique({
+          where: { id: userId },
+          select: { id: true, email: true, phone: true },
+        });
+      } else {
+        return await prisma.profile.findUnique({
+          where: { email },
+          select: { id: true, email: true, phone: true },
+        });
+      }
+    }, 3, 'findProfileForPhoneSync');
+
+    if (!profile) {
+      logger.warn(`[PROFILE-SYNC] No profile found for ${userId ? `userId: ${userId}` : `email: ${email}`}`);
+      return false;
+    }
+
+    // Only update if phone is different or missing
+    if (profile.phone !== trimmedPhone) {
+      logger.info(`[PROFILE-SYNC] Updating phone for profile ${profile.id}: ${profile.phone || 'none'} -> ${trimmedPhone}`);
+
+      await withRetry(async () => {
+        return await prisma.profile.update({
+          where: { id: profile.id },
+          data: {
+            phone: trimmedPhone,
+            updated_at: new Date(),
+          },
+        });
+      }, 3, 'updateProfilePhone');
+
+      logger.info(`[PROFILE-SYNC] Successfully updated phone for profile ${profile.id}`);
+      return true;
+    } else {
+      logger.debug(`[PROFILE-SYNC] Phone already up-to-date for profile ${profile.id}`);
+      return true;
+    }
+  } catch (error) {
+    logger.error('[PROFILE-SYNC] Error syncing phone to profile:', error);
+    // Don't throw - we don't want to fail the order if profile sync fails
+    return false;
+  }
+}
+
+/**
+ * Syncs multiple customer fields to their profile
+ * This is a more comprehensive sync for name, email, and phone
+ *
+ * @param userId - The user's ID (optional for guest checkouts)
+ * @param data - Customer data to sync
+ * @returns Promise<boolean> - Success status
+ */
+export async function syncCustomerToProfile(
+  userId: string | null | undefined,
+  data: {
+    email: string;
+    name?: string;
+    phone?: string;
+  }
+): Promise<boolean> {
+  try {
+    // Find the profile by userId or email
+    const profile = await withRetry(async () => {
+      if (userId) {
+        return await prisma.profile.findUnique({
+          where: { id: userId },
+          select: { id: true, email: true, name: true, phone: true },
+        });
+      } else {
+        return await prisma.profile.findUnique({
+          where: { email: data.email },
+          select: { id: true, email: true, name: true, phone: true },
+        });
+      }
+    }, 3, 'findProfileForCustomerSync');
+
+    if (!profile) {
+      logger.warn(`[PROFILE-SYNC] No profile found for ${userId ? `userId: ${userId}` : `email: ${data.email}`}`);
+      return false;
+    }
+
+    // Build update data object with only changed fields
+    const updateData: any = {
+      updated_at: new Date(),
+    };
+
+    let hasChanges = false;
+
+    if (data.name && data.name.trim() !== profile.name) {
+      updateData.name = data.name.trim();
+      hasChanges = true;
+      logger.info(`[PROFILE-SYNC] Name update: ${profile.name || 'none'} -> ${data.name.trim()}`);
+    }
+
+    if (data.phone && data.phone.trim() !== profile.phone) {
+      updateData.phone = data.phone.trim();
+      hasChanges = true;
+      logger.info(`[PROFILE-SYNC] Phone update: ${profile.phone || 'none'} -> ${data.phone.trim()}`);
+    }
+
+    if (hasChanges) {
+      await withRetry(async () => {
+        return await prisma.profile.update({
+          where: { id: profile.id },
+          data: updateData,
+        });
+      }, 3, 'updateProfileCustomerData');
+
+      logger.info(`[PROFILE-SYNC] Successfully updated profile ${profile.id}`);
+      return true;
+    } else {
+      logger.debug(`[PROFILE-SYNC] No changes needed for profile ${profile.id}`);
+      return true;
+    }
+  } catch (error) {
+    logger.error('[PROFILE-SYNC] Error syncing customer data to profile:', error);
+    // Don't throw - we don't want to fail the order if profile sync fails
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
Fixes phone number sync issue across regular checkout and catering order flows. Customer phone numbers are now automatically synced to their user profiles whenever they place an order.

## Changes Made

### 1. Created Centralized Profile Sync Utility (`src/lib/profile-sync.ts`)
- `syncPhoneToProfile()` - Syncs phone number only
- `syncCustomerToProfile()` - Syncs name and phone number
- Includes robust error handling and logging
- Non-blocking to prevent order failures

### 2. Updated Regular Checkout Route (`src/app/api/checkout/route.ts`)
- Added profile sync after order creation
- Syncs customer name, email, and phone to user profile
- Uses non-blocking async call with error catching

### 3. Updated Catering Order Creation (`src/actions/catering.ts`)
- Added profile sync in `saveContactInfo()` function
- Syncs customer data for both Square and cash payment flows
- Consistent with regular checkout implementation

## How It Works

When a customer places an order (regular or catering):
1. Order is created in the database with customer information
2. Profile sync is triggered asynchronously (non-blocking)
3. If the customer has a profile (by userId or email), their phone and name are updated
4. If sync fails, order still succeeds (logged for debugging)

## Testing

The sync works for:
- ✅ Authenticated users (via userId)
- ✅ Guest users (via email lookup)
- ✅ Regular checkout flow
- ✅ Catering checkout flow (Square & Cash payments)
- ✅ Manual profile updates on `/account` page (already existed)

## Quality Assurance

- ✅ TypeScript compilation passes
- ✅ Production build succeeds
- ✅ Code follows existing patterns
- ✅ Non-blocking implementation prevents order failures
- ✅ Comprehensive logging for debugging

## Note
Account page (`/account`) already handles manual phone number updates correctly. This PR adds automatic syncing during order placement.

Fixes: DES-30

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>