### PR TITLE
fix: prevent double slash in URL construction (DES-56)

### DIFF
--- a/src/app/(dashboard)/admin/products/[id]/page.tsx
+++ b/src/app/(dashboard)/admin/products/[id]/page.tsx
@@ -170,11 +170,14 @@ export default async function EditProductPage({ params, searchParams }: PageProp
       });
       logger.info('Database update successful');
 
+      // Clean app URL to prevent double slashes
+      const cleanAppUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+
       // Revalidate both pages
       await Promise.all([
-        fetch(`${env.NEXT_PUBLIC_APP_URL}/api/revalidate?path=/admin/products`),
+        fetch(`${cleanAppUrl}/api/revalidate?path=/admin/products`),
         fetch(
-          `${env.NEXT_PUBLIC_APP_URL}/api/revalidate?path=/admin/products/${productId}`
+          `${cleanAppUrl}/api/revalidate?path=/admin/products/${productId}`
         ),
       ]);
 

--- a/src/app/api/admin/validate-routes/route.ts
+++ b/src/app/api/admin/validate-routes/route.ts
@@ -82,9 +82,12 @@ export async function GET() {
 }
 
 async function validateSquareRoutes(validations: RouteValidation[], criticalIssues: string[]) {
+  // Clean app URL to prevent double slashes
+  const cleanAppUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+
   // Validate Square sync route
   try {
-    const response = await fetch(`${env.NEXT_PUBLIC_APP_URL}/api/square/sync`, {
+    const response = await fetch(`${cleanAppUrl}/api/square/sync`, {
       method: 'HEAD',
     });
 
@@ -141,9 +144,12 @@ async function validateSquareRoutes(validations: RouteValidation[], criticalIssu
 }
 
 async function validateProductRoutes(validations: RouteValidation[], criticalIssues: string[]) {
+  // Clean app URL to prevent double slashes
+  const cleanAppUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+
   // Validate products API
   try {
-    const response = await fetch(`${env.NEXT_PUBLIC_APP_URL}/api/products?limit=1`, {
+    const response = await fetch(`${cleanAppUrl}/api/products?limit=1`, {
       method: 'GET',
     });
 

--- a/src/app/api/debug/auth-config/route.ts
+++ b/src/app/api/debug/auth-config/route.ts
@@ -11,6 +11,9 @@ interface Recommendation {
 
 export async function GET() {
   try {
+    // Clean app URL to prevent double slashes
+    const cleanAppUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+
     const diagnostics = {
       timestamp: new Date().toISOString(),
       environment: {
@@ -22,8 +25,8 @@ export async function GET() {
       },
       urls: {
         current_site_url: env.NEXT_PUBLIC_APP_URL,
-        callback_url: `${env.NEXT_PUBLIC_APP_URL}/auth/callback`,
-        magic_link_redirect: `${env.NEXT_PUBLIC_APP_URL}/auth/callback?redirect_to=/admin`,
+        callback_url: `${cleanAppUrl}/auth/callback`,
+        magic_link_redirect: `${cleanAppUrl}/auth/callback?redirect_to=/admin`,
       },
       supabase_config_check: {},
       recommendations: [] as Recommendation[],

--- a/src/app/api/orders/[orderId]/retry-payment/route.ts
+++ b/src/app/api/orders/[orderId]/retry-payment/route.ts
@@ -101,7 +101,7 @@ export async function POST(request: NextRequest, { params }: { params: any }) {
     }
 
     // Prepare order items based on order type
-    const orderItems = isRegularOrder 
+    const orderItems = isRegularOrder
       ? order!.items.map(item => ({
           quantity: item.quantity,
           price: item.price,
@@ -115,14 +115,17 @@ export async function POST(request: NextRequest, { params }: { params: any }) {
           variant: null,
         }));
 
+    // Clean app URL to prevent double slashes
+    const cleanAppUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+
     // Create new Square checkout session
-    const redirectUrl = isRegularOrder 
-      ? `${env.NEXT_PUBLIC_APP_URL}/checkout/success?orderId=${targetOrder!.id}`
-      : `${env.NEXT_PUBLIC_APP_URL}/catering/confirmation?status=success&orderId=${targetOrder!.id}`;
+    const redirectUrl = isRegularOrder
+      ? `${cleanAppUrl}/checkout/success?orderId=${targetOrder!.id}`
+      : `${cleanAppUrl}/catering/confirmation?status=success&orderId=${targetOrder!.id}`;
 
     const cancelUrl = isRegularOrder
-      ? `${env.NEXT_PUBLIC_APP_URL}/orders/${targetOrder!.id}?payment=cancelled`
-      : `${env.NEXT_PUBLIC_APP_URL}/catering/confirmation?status=cancelled&orderId=${targetOrder!.id}`;
+      ? `${cleanAppUrl}/orders/${targetOrder!.id}?payment=cancelled`
+      : `${cleanAppUrl}/catering/confirmation?status=cancelled&orderId=${targetOrder!.id}`;
 
     // Format items for the existing working checkout function
     const lineItems = orderItems.map(item => ({

--- a/src/emails/alerts/AdminNewOrderAlert.tsx
+++ b/src/emails/alerts/AdminNewOrderAlert.tsx
@@ -61,6 +61,9 @@ export const AdminNewOrderAlert: React.FC<AdminNewOrderAlertProps> = ({
   timestamp,
   totalOrdersToday,
 }) => {
+  // Clean app URL to prevent double slashes
+  const cleanAppUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+
   const formattedTimestamp = timestamp.toLocaleString('en-US', {
     timeZone: 'America/Los_Angeles',
     weekday: 'short',
@@ -420,7 +423,7 @@ export const AdminNewOrderAlert: React.FC<AdminNewOrderAlertProps> = ({
 
           <Section style={styles.actionSection}>
             <Link
-              href={`${env.NEXT_PUBLIC_APP_URL}/admin/orders/${order.id}`}
+              href={`${cleanAppUrl}/admin/orders/${order.id}`}
               style={styles.actionButton}
             >
               View Order in Admin

--- a/src/emails/alerts/OrderStatusChangeAlert.tsx
+++ b/src/emails/alerts/OrderStatusChangeAlert.tsx
@@ -25,6 +25,9 @@ export const OrderStatusChangeAlert: React.FC<OrderStatusChangeAlertProps> = ({
   timestamp,
   isCustomer,
 }) => {
+  // Clean app URL to prevent double slashes
+  const cleanAppUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+
   const formattedTotal = Number(order.total).toFixed(2);
   const formattedTimestamp = timestamp.toLocaleString('en-US', {
     timeZone: 'America/Los_Angeles',
@@ -190,7 +193,7 @@ export const OrderStatusChangeAlert: React.FC<OrderStatusChangeAlertProps> = ({
           {!isCustomer && (
             <Section style={styles.adminActionSection}>
               <Link
-                href={`${env.NEXT_PUBLIC_APP_URL}/admin/orders/${order.id}`}
+                href={`${cleanAppUrl}/admin/orders/${order.id}`}
                 style={styles.adminButton}
               >
                 View Order in Admin

--- a/src/emails/alerts/PaymentFailedAlert.tsx
+++ b/src/emails/alerts/PaymentFailedAlert.tsx
@@ -23,6 +23,9 @@ export const PaymentFailedAlert: React.FC<PaymentFailedAlertProps> = ({
   error,
   timestamp,
 }) => {
+  // Clean app URL to prevent double slashes
+  const cleanAppUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
+
   const formattedTotal = Number(order.total).toFixed(2);
   const formattedTimestamp = timestamp.toLocaleString('en-US', {
     timeZone: 'America/Los_Angeles',
@@ -187,7 +190,7 @@ export const PaymentFailedAlert: React.FC<PaymentFailedAlertProps> = ({
 
           <Section style={styles.quickActions}>
             <Link
-              href={`${env.NEXT_PUBLIC_APP_URL}/admin/orders/${order.id}`}
+              href={`${cleanAppUrl}/admin/orders/${order.id}`}
               style={styles.primaryButton}
             >
               View Order in Admin


### PR DESCRIPTION
**Problem:**
When retrying payment from the account page, URLs were constructed with double slashes (e.g., `//checkout/success`) if NEXT_PUBLIC_APP_URL had a trailing slash, causing redirect failures.

**Solution:**
Added URL cleaning logic to remove trailing slashes before concatenating paths throughout the codebase. Applied pattern:
```typescript
const cleanAppUrl = env.NEXT_PUBLIC_APP_URL.replace(/\/$/, '');
```

**Files Fixed:**
- ✅ retry-payment API route (primary issue)
- ✅ validate-routes API (2 occurrences)
- ✅ debug auth-config API (2 occurrences)
- ✅ admin products page (2 occurrences)
- ✅ OrderStatusChangeAlert email (1 occurrence)
- ✅ PaymentFailedAlert email (1 occurrence)
- ✅ AdminNewOrderAlert email (1 occurrence)

**Total:** 9 occurrences fixed across 7 files

**Testing:**
- ✅ TypeScript type check passed
- ✅ Critical tests passed
- Pattern matches existing solution in catering.ts:684

**Related:** DES-56