### PR TITLE
fix(db): Prisma retry cleanup and production error noise reduction

### DIFF
--- a/src/app/api/spotlight-picks/route.ts
+++ b/src/app/api/spotlight-picks/route.ts
@@ -1,39 +1,32 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SpotlightAPIResponse, SpotlightPick } from '@/types/spotlight';
-import { prisma, withRetry } from '@/lib/db-unified';
-import { safeCateringApiOperation } from '@/lib/catering-api-utils';
+import { prisma } from '@/lib/db-unified';
 
 // DES-81: Increase function timeout for database connection resilience
 export const maxDuration = 60;
 
 async function getSpotlightPicks(): Promise<SpotlightPick[]> {
-  // Fetch spotlight picks with product data using Prisma
-  const rawSpotlightPicks = await withRetry(
-    async () => {
-      return await prisma.spotlightPick.findMany({
-        where: {
-          isActive: true,
-        },
+  // The prisma proxy already wraps every query in withRetry, so no need for an extra layer
+  const rawSpotlightPicks = await prisma.spotlightPick.findMany({
+    where: {
+      isActive: true,
+    },
+    include: {
+      product: {
         include: {
-          product: {
-            include: {
-              category: {
-                select: {
-                  name: true,
-                  slug: true,
-                },
-              },
+          category: {
+            select: {
+              name: true,
+              slug: true,
             },
           },
         },
-        orderBy: {
-          position: 'asc',
-        },
-      });
+      },
     },
-    3,
-    'spotlight-picks-fetch'
-  );
+    orderBy: {
+      position: 'asc',
+    },
+  });
 
   // Transform the data to match our interface
   return rawSpotlightPicks

--- a/src/components/Marketing/FeaturedProductsServer.tsx
+++ b/src/components/Marketing/FeaturedProductsServer.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { unstable_noStore as noStore } from 'next/cache';
 import { Dancing_Script } from 'next/font/google';
-import { prisma, withRetry } from '@/lib/db-unified';
+import { prisma } from '@/lib/db-unified';
 import { truncateHtmlDescription } from '@/lib/utils/product-description';
 import type { SpotlightPick } from '@/types/spotlight';
 
@@ -17,27 +17,22 @@ async function getSpotlightPicks(): Promise<SpotlightPick[]> {
   // The Suspense boundary in the parent page shows a skeleton while this loads.
   noStore();
 
-  const rawPicks = await withRetry(
-    async () => {
-      return await prisma.spotlightPick.findMany({
-        where: {
-          isActive: true,
-        },
+  // The prisma proxy already wraps every query in withRetry, so no need for an extra layer
+  const rawPicks = await prisma.spotlightPick.findMany({
+    where: {
+      isActive: true,
+    },
+    include: {
+      product: {
         include: {
-          product: {
-            include: {
-              category: {
-                select: { name: true, slug: true },
-              },
-            },
+          category: {
+            select: { name: true, slug: true },
           },
         },
-        orderBy: { position: 'asc' },
-      });
+      },
     },
-    3,
-    'spotlight-picks-server-fetch'
-  );
+    orderBy: { position: 'asc' },
+  });
 
   return rawPicks
     .filter(pick => pick.product && pick.productId)

--- a/src/lib/db-unified.ts
+++ b/src/lib/db-unified.ts
@@ -186,10 +186,14 @@ async function createPrismaClient(retryAttempt: number = 0): Promise<PrismaClien
     },
   });
 
-  // Add error handling for production
+  // Add error handling for production — log as warning since transient
+  // engine errors are handled by withRetry and don't affect query results
   if (isProduction) {
     client.$on('error' as never, (e: any) => {
-      console.error('Prisma error:', e);
+      console.warn('[PRISMA_ENGINE_EVENT]', {
+        message: typeof e?.message === 'string' ? e.message.substring(0, 200) : 'unknown',
+        timestamp: new Date().toISOString(),
+      });
     });
   }
 

--- a/src/lib/spotlight-picks.ts
+++ b/src/lib/spotlight-picks.ts
@@ -1,33 +1,28 @@
 import { SpotlightPick } from '@/types/spotlight';
-import { prisma, withRetry } from '@/lib/db-unified';
+import { prisma } from '@/lib/db-unified';
 
 export async function getSpotlightPicks(): Promise<SpotlightPick[]> {
-  const rawSpotlightPicks = await withRetry(
-    async () => {
-      return await prisma.spotlightPick.findMany({
-        where: {
-          isActive: true,
-        },
+  // The prisma proxy already wraps every query in withRetry, so no need for an extra layer
+  const rawSpotlightPicks = await prisma.spotlightPick.findMany({
+    where: {
+      isActive: true,
+    },
+    include: {
+      product: {
         include: {
-          product: {
-            include: {
-              category: {
-                select: {
-                  name: true,
-                  slug: true,
-                },
-              },
+          category: {
+            select: {
+              name: true,
+              slug: true,
             },
           },
         },
-        orderBy: {
-          position: 'asc',
-        },
-      });
+      },
     },
-    3,
-    'spotlight-picks-fetch'
-  );
+    orderBy: {
+      position: 'asc',
+    },
+  });
 
   return rawSpotlightPicks
     .filter(pick => pick.product && pick.productId)


### PR DESCRIPTION
## Summary
- Remove redundant `withRetry` wrappers from spotlight-picks queries — the `prisma` proxy already retries every query (3 attempts), so the outer `withRetry` caused up to 9 retry attempts and duplicate error logs
- Downgrade Prisma engine `$on('error')` handler from `console.error` to `console.warn` with structured output — these transient engine events are handled by retry and don't affect query results, eliminating false-alarm error logs in Vercel

## Test plan
- [x] TypeScript type-check passes
- [x] All 1,425 tests passing
- [x] Vercel preview deployment builds successfully
- [x] Spotlight picks render correctly on homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)