### PR TITLE
feat(admin): add Square writeback health endpoint

### DIFF
--- a/src/__tests__/app/api/admin/square-writeback-health.test.ts
+++ b/src/__tests__/app/api/admin/square-writeback-health.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the Square writeback health endpoint.
+ *
+ * Verifies admin auth gating and the shape/semantics of the health payload
+ * (job counts, conflict count, lag math, recent failures, echo records).
+ */
+
+const mockVerifyAdminAccess = jest.fn();
+
+jest.mock('@/lib/auth/admin-guard', () => ({
+  verifyAdminAccess: (...args: unknown[]) => mockVerifyAdminAccess(...args),
+}));
+
+const prismaMock = {
+  squareWriteJob: {
+    groupBy: jest.fn(),
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+  },
+  product: { count: jest.fn() },
+  recentSquareWrite: { count: jest.fn() },
+};
+jest.mock('@/lib/db-unified', () => ({ prisma: prismaMock, withRetry: (fn: () => unknown) => fn() }));
+
+jest.mock('@/lib/square/write-queue', () => ({
+  isWritebackEnabled: jest.fn(() => true),
+}));
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => Promise.resolve({ getAll: () => [] })),
+}));
+
+import { GET } from '@/app/api/admin/square-writeback-health/route';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GET /api/admin/square-writeback-health', () => {
+  it('returns 401 when not authenticated', async () => {
+    mockVerifyAdminAccess.mockResolvedValue({
+      authorized: false,
+      error: 'Authentication required',
+      statusCode: 401,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Authentication required' });
+  });
+
+  it('returns 403 when authenticated but not admin', async () => {
+    mockVerifyAdminAccess.mockResolvedValue({
+      authorized: false,
+      error: 'Admin access required',
+      statusCode: 403,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it('returns healthy when no failures and no lag', async () => {
+    mockVerifyAdminAccess.mockResolvedValue({ authorized: true, user: { id: 'u', email: 'a@b', role: 'ADMIN' } });
+    prismaMock.squareWriteJob.groupBy.mockResolvedValue([
+      { status: 'SUCCEEDED', _count: { _all: 12 } },
+    ]);
+    prismaMock.product.count.mockResolvedValue(0);
+    prismaMock.squareWriteJob.findFirst
+      .mockResolvedValueOnce({
+        succeededAt: new Date(Date.now() - 30_000),
+        operation: 'CREATE',
+        productId: 'p1',
+      })
+      .mockResolvedValueOnce(null);
+    prismaMock.squareWriteJob.findMany.mockResolvedValue([]);
+    prismaMock.recentSquareWrite.count.mockResolvedValue(2);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.health).toBe('healthy');
+    expect(body.featureEnabled).toBe(true);
+    expect(body.jobs.counts).toEqual({ PENDING: 0, SUCCEEDED: 12, FAILED: 0, DEAD: 0 });
+    expect(body.jobs.lastSucceeded.ageMs).toBeGreaterThanOrEqual(30_000);
+    expect(body.jobs.oldestPending).toBeNull();
+    expect(body.products.conflictCount).toBe(0);
+    expect(body.echoSuppression.activeRecords).toBe(2);
+  });
+
+  it('returns degraded when there are FAILED jobs', async () => {
+    mockVerifyAdminAccess.mockResolvedValue({ authorized: true, user: { id: 'u', email: 'a@b', role: 'ADMIN' } });
+    prismaMock.squareWriteJob.groupBy.mockResolvedValue([
+      { status: 'SUCCEEDED', _count: { _all: 10 } },
+      { status: 'FAILED', _count: { _all: 1 } },
+    ]);
+    prismaMock.product.count.mockResolvedValue(0);
+    prismaMock.squareWriteJob.findFirst.mockResolvedValue(null);
+    prismaMock.squareWriteJob.findMany.mockResolvedValue([
+      {
+        id: 'j1',
+        status: 'FAILED',
+        operation: 'UPDATE',
+        productId: 'p1',
+        attempts: 1,
+        lastError: 'VERSION_MISMATCH',
+        updatedAt: new Date(),
+      },
+    ]);
+    prismaMock.recentSquareWrite.count.mockResolvedValue(0);
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.health).toBe('degraded');
+    expect(body.jobs.recentFailures).toHaveLength(1);
+    expect(body.jobs.recentFailures[0].lastError).toBe('VERSION_MISMATCH');
+  });
+
+  it('returns unhealthy when there are DEAD jobs', async () => {
+    mockVerifyAdminAccess.mockResolvedValue({ authorized: true, user: { id: 'u', email: 'a@b', role: 'ADMIN' } });
+    prismaMock.squareWriteJob.groupBy.mockResolvedValue([
+      { status: 'DEAD', _count: { _all: 1 } },
+    ]);
+    prismaMock.product.count.mockResolvedValue(0);
+    prismaMock.squareWriteJob.findFirst.mockResolvedValue(null);
+    prismaMock.squareWriteJob.findMany.mockResolvedValue([]);
+    prismaMock.recentSquareWrite.count.mockResolvedValue(0);
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.health).toBe('unhealthy');
+  });
+
+  it('returns unhealthy when there are CONFLICT products', async () => {
+    mockVerifyAdminAccess.mockResolvedValue({ authorized: true, user: { id: 'u', email: 'a@b', role: 'ADMIN' } });
+    prismaMock.squareWriteJob.groupBy.mockResolvedValue([]);
+    prismaMock.product.count.mockResolvedValue(3);
+    prismaMock.squareWriteJob.findFirst.mockResolvedValue(null);
+    prismaMock.squareWriteJob.findMany.mockResolvedValue([]);
+    prismaMock.recentSquareWrite.count.mockResolvedValue(0);
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.health).toBe('unhealthy');
+    expect(body.products.conflictCount).toBe(3);
+  });
+
+  it('returns degraded when oldest pending job is older than 5 minutes', async () => {
+    mockVerifyAdminAccess.mockResolvedValue({ authorized: true, user: { id: 'u', email: 'a@b', role: 'ADMIN' } });
+    prismaMock.squareWriteJob.groupBy.mockResolvedValue([
+      { status: 'PENDING', _count: { _all: 1 } },
+    ]);
+    prismaMock.product.count.mockResolvedValue(0);
+    const sixMinAgo = new Date(Date.now() - 6 * 60_000);
+    prismaMock.squareWriteJob.findFirst
+      .mockResolvedValueOnce(null) // last succeeded
+      .mockResolvedValueOnce({
+        createdAt: sixMinAgo,
+        attempts: 0,
+        operation: 'CREATE',
+        productId: 'p2',
+      });
+    prismaMock.squareWriteJob.findMany.mockResolvedValue([]);
+    prismaMock.recentSquareWrite.count.mockResolvedValue(0);
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.health).toBe('degraded');
+    expect(body.jobs.oldestPending.ageMs).toBeGreaterThan(5 * 60_000);
+  });
+});

--- a/src/app/api/admin/square-writeback-health/route.ts
+++ b/src/app/api/admin/square-writeback-health/route.ts
@@ -1,0 +1,154 @@
+/**
+ * Admin health endpoint for the Destino → Square writeback queue.
+ *
+ * Surfaces metrics for the admin dashboard:
+ *   - Job counts by status (PENDING / SUCCEEDED / FAILED / DEAD)
+ *   - Product CONFLICT count
+ *   - Last successful write timestamp + queue lag
+ *   - Recent failures (last 5) with error messages
+ *   - Active echo-suppression record count
+ *   - Feature-flag status
+ *
+ * GET /api/admin/square-writeback-health
+ */
+
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/db-unified';
+import { verifyAdminAccess } from '@/lib/auth/admin-guard';
+import { isWritebackEnabled } from '@/lib/square/write-queue';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const ECHO_TTL_MS = 5 * 60 * 1000;
+
+export async function GET(): Promise<NextResponse> {
+  const adminCheck = await verifyAdminAccess();
+  if (!adminCheck.authorized) {
+    return NextResponse.json(
+      { error: adminCheck.error },
+      { status: adminCheck.statusCode ?? 401 }
+    );
+  }
+
+  try {
+    const echoCutoff = new Date(Date.now() - ECHO_TTL_MS);
+
+    const [
+      jobsByStatus,
+      conflictCount,
+      lastSucceededJob,
+      oldestPendingJob,
+      recentFailures,
+      activeEchoCount,
+    ] = await Promise.all([
+      prisma.squareWriteJob.groupBy({
+        by: ['status'],
+        _count: { _all: true },
+      }),
+      prisma.product.count({ where: { syncStatus: 'CONFLICT' } }),
+      prisma.squareWriteJob.findFirst({
+        where: { status: 'SUCCEEDED' },
+        orderBy: { succeededAt: 'desc' },
+        select: { succeededAt: true, operation: true, productId: true },
+      }),
+      prisma.squareWriteJob.findFirst({
+        where: { status: 'PENDING' },
+        orderBy: { createdAt: 'asc' },
+        select: { createdAt: true, attempts: true, operation: true, productId: true },
+      }),
+      prisma.squareWriteJob.findMany({
+        where: { status: { in: ['FAILED', 'DEAD'] } },
+        orderBy: { updatedAt: 'desc' },
+        take: 5,
+        select: {
+          id: true,
+          status: true,
+          operation: true,
+          productId: true,
+          attempts: true,
+          lastError: true,
+          updatedAt: true,
+        },
+      }),
+      prisma.recentSquareWrite.count({ where: { writtenAt: { gte: echoCutoff } } }),
+    ]);
+
+    const counts: Record<string, number> = {
+      PENDING: 0,
+      SUCCEEDED: 0,
+      FAILED: 0,
+      DEAD: 0,
+    };
+    for (const row of jobsByStatus) {
+      counts[row.status] = row._count._all;
+    }
+
+    const oldestPendingAgeMs = oldestPendingJob
+      ? Date.now() - oldestPendingJob.createdAt.getTime()
+      : null;
+
+    const lastSucceededAgeMs = lastSucceededJob?.succeededAt
+      ? Date.now() - lastSucceededJob.succeededAt.getTime()
+      : null;
+
+    // Surface a simple healthy/degraded/unhealthy signal so the admin UI
+    // can render a single status pill without re-implementing the math.
+    const health =
+      counts.DEAD > 0 || conflictCount > 0
+        ? 'unhealthy'
+        : counts.FAILED > 0 || (oldestPendingAgeMs !== null && oldestPendingAgeMs > 5 * 60_000)
+          ? 'degraded'
+          : 'healthy';
+
+    return NextResponse.json({
+      timestamp: new Date().toISOString(),
+      featureEnabled: isWritebackEnabled(),
+      health,
+      jobs: {
+        counts,
+        oldestPending: oldestPendingJob
+          ? {
+              productId: oldestPendingJob.productId,
+              operation: oldestPendingJob.operation,
+              attempts: oldestPendingJob.attempts,
+              createdAt: oldestPendingJob.createdAt.toISOString(),
+              ageMs: oldestPendingAgeMs,
+            }
+          : null,
+        lastSucceeded: lastSucceededJob?.succeededAt
+          ? {
+              productId: lastSucceededJob.productId,
+              operation: lastSucceededJob.operation,
+              succeededAt: lastSucceededJob.succeededAt.toISOString(),
+              ageMs: lastSucceededAgeMs,
+            }
+          : null,
+        recentFailures: recentFailures.map(f => ({
+          id: f.id,
+          status: f.status,
+          operation: f.operation,
+          productId: f.productId,
+          attempts: f.attempts,
+          lastError: f.lastError,
+          updatedAt: f.updatedAt.toISOString(),
+        })),
+      },
+      products: {
+        conflictCount,
+      },
+      echoSuppression: {
+        activeRecords: activeEchoCount,
+        ttlMs: ECHO_TTL_MS,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: 'Failed to compute writeback health',
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/admin/square-writeback-health` so the admin UI can render a single status pill plus drill-in detail for the Destino → Square writeback queue without re-implementing the SQL.
- Surfaces job counts, queue lag, recent failures, conflict products, and active echo-suppression record count — everything you'd otherwise hand-write `SELECT … FROM square_write_jobs GROUP BY status` for.

## Response shape

```json
{
  "timestamp": "2026-04-16T19:00:00.000Z",
  "featureEnabled": true,
  "health": "healthy",
  "jobs": {
    "counts": { "PENDING": 0, "SUCCEEDED": 12, "FAILED": 0, "DEAD": 0 },
    "oldestPending": null,
    "lastSucceeded": {
      "productId": "...",
      "operation": "CREATE",
      "succeededAt": "2026-04-16T18:59:30.000Z",
      "ageMs": 30000
    },
    "recentFailures": []
  },
  "products": { "conflictCount": 0 },
  "echoSuppression": { "activeRecords": 2, "ttlMs": 300000 }
}
```

`health` rollup logic:
- `unhealthy`: any `DEAD` jobs **OR** any product in `CONFLICT`
- `degraded`: any `FAILED` jobs **OR** oldest `PENDING` > 5 min
- `healthy`: otherwise

## Tests

`src/__tests__/app/api/admin/square-writeback-health.test.ts` — 7 unit tests:
- 401 when unauthenticated, 403 when not admin (matches existing admin-route convention via `verifyAdminAccess`).
- `healthy` when no failures and no lag.
- `degraded` when there are FAILED jobs.
- `unhealthy` when there are DEAD jobs.
- `unhealthy` when there are CONFLICT products.
- `degraded` when oldest PENDING is older than 5 min.

`pnpm type-check` passes; tests green locally.

## Test plan

- [x] All 7 unit tests green.
- [x] `pnpm type-check` clean.
- [ ] Post-merge: `curl https://<prod>/api/admin/square-writeback-health` without admin cookie → 401.
- [ ] Post-merge: `curl` with admin session → 200 with `health: \"healthy\"` (queue is empty in production right now).
- [ ] Once `ENABLE_SQUARE_WRITEBACK=true` in staging: create a test product, hit the endpoint, confirm `lastSucceeded` shows the CREATE within ~2 min.

## Notes for reviewer

- Merge with **Rebase and merge** or **Create a merge commit** per CLAUDE.md §11 — never Squash.
- No DB schema changes; this is a pure read-only endpoint over the tables added in #144.
- Frontend dashboard component to consume this endpoint is intentionally **not** in this PR — wanted the data surface available first so we can iterate on the UI separately without coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)