### PR TITLE
chore(square): apply MCP verification follow-ups to catalog-write

### DIFF
--- a/src/lib/square/catalog-write.ts
+++ b/src/lib/square/catalog-write.ts
@@ -13,7 +13,10 @@ import { logger } from '@/utils/logger';
 
 const SQUARE_API_TIMEOUT_MS = 45_000;
 const SQUARE_SOCKET_TIMEOUT_MS = 50_000;
-const SQUARE_VERSION_HEADER = '2024-10-17';
+// Match the version used by the rest of the codebase (orders, payments, labor,
+// checkout-links, client-adapter). Square deprecates API versions ~1 year after
+// release, so keep this in sync with the other Square integration modules.
+const SQUARE_VERSION_HEADER = '2025-05-21';
 
 export type WriteErrorCode =
   | 'NETWORK'
@@ -299,6 +302,25 @@ export async function updateSquareItem(input: UpdateItemInput): Promise<UpdateIt
   return { version: BigInt(res.catalog_object.version ?? 0) };
 }
 
+/**
+ * How an archive propagates to Square. Note that "archive" here means the
+ * admin-visible action in the Destino dashboard; Square itself doesn't have
+ * an "archive" concept — we either delete the object or hide it at all
+ * locations.
+ *
+ * - `'hide'` (default) — upserts the object with `present_at_all_locations=false`,
+ *   removing it from every location without deleting. The object stays in
+ *   Square's catalog with the same ID/version, so the admin's "restore"
+ *   action can just UPDATE it back to `present_at_all_locations=true`. This
+ *   preserves the round-trip archive/restore semantics the admin UI expects.
+ * - `'delete'` — true soft-delete via `DELETE /v2/catalog/object/{id}`. Square
+ *   sets `is_deleted=true` server-side; the object is retained for history
+ *   but becomes un-updateable via the API. Unarchiving a delete-archived
+ *   product would require recreating it as a new Square object (NOT supported
+ *   by the current UNARCHIVE path). Use this only for permanent removal.
+ *
+ * Override via `SQUARE_ARCHIVE_MODE=delete` or by passing `mode` explicitly.
+ */
 export type ArchiveMode = 'delete' | 'hide';
 
 export interface ArchiveItemInput {


### PR DESCRIPTION
## Summary

Two small non-blocking improvements surfaced by verifying our writeback implementation against Square's official type info via the Square MCP server. Neither changes the happy-path behavior.

### 1. Bump Square-Version header from `2024-10-17` to `2025-05-21`

`catalog-write.ts` was the only Square integration still on the old version. The rest of the codebase — `orders.ts`, `payments-api.ts`, `labor-api.ts`, `checkout-links.ts`, `client-adapter.js`, `fix-images-direct/route.ts` — already sends `2025-05-21`. Square deprecates API versions ~1 year after release, so `2024-10-17` was getting close to the window.

\`catalog-api.ts\` (read path) is still on `2024-10-17`. Aligning that is a separate concern because it has its own test coverage and a wider blast radius — intentionally out of scope for this PR.

### 2. Clarify the `ArchiveMode` JSDoc

During verification I almost flipped the default from `'hide'` to `'delete'` based on a misread of the MCP-verification agent's recommendation. The existing default (`'hide'`) is actually correct: it preserves round-trip archive/restore semantics because our `UNARCHIVE` operation routes through `updateSquareItem`, which requires the Square object to still exist. `'delete'` tombstones the object (`is_deleted=true`) and breaks unarchive.

Added a detailed JSDoc block on `ArchiveMode` explaining:
- `'hide'` (default) — upsert with `present_at_all_locations=false`; restorable via UPDATE.
- `'delete'` — true Square soft-delete; unarchive is **not** supported from this state.

No code behavior change — only the type/comment surface is new.

## Test plan

- [x] `pnpm type-check` clean.
- [x] All 24 existing unit tests (`catalog-write`, `write-queue`, `echo-suppression`) pass.
- [ ] Post-merge: confirm staging writeback still works end-to-end (no regressions from the Square-Version bump).

## Notes for reviewer

- Merge with **Rebase and merge** or **Create a merge commit** per CLAUDE.md §11 — never Squash.
- Behavior change on archive path: **none**. Default is still `'hide'`.
- Behavior change from version bump: Square hasn't made breaking changes between `2024-10-17` and `2025-05-21` for the catalog endpoints we use (`upsertCatalogObject`, `deleteCatalogObject`). Confirmed by inspecting the MCP type info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)