### PR TITLE
chore: add gstack skill routing rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -635,3 +635,23 @@ The following architectural changes were made during the Q2 2026 audit (see `doc
 - Catering system: `docs/README_CATERING.md`
 - Square setup: `docs/SQUARE_TOKEN_SETUP.md`
 - Shipping integration: `docs/ENHANCED_SHIPPO_INTEGRATION.md`
+
+## Skill routing
+
+When the user's request matches an available skill, ALWAYS invoke it using the Skill
+tool as your FIRST action. Do NOT answer directly, do NOT use other tools first.
+The skill has specialized workflows that produce better results than ad-hoc answers.
+
+Key routing rules:
+- Product ideas, "is this worth building", brainstorming → invoke office-hours
+- Bugs, errors, "why is this broken", 500 errors → invoke investigate
+- Ship, deploy, push, create PR → invoke ship
+- QA, test the site, find bugs → invoke qa
+- Code review, check my diff → invoke review
+- Update docs after shipping → invoke document-release
+- Weekly retro → invoke retro
+- Design system, brand → invoke design-consultation
+- Visual audit, design polish → invoke design-review
+- Architecture review → invoke plan-eng-review
+- Save progress, checkpoint, resume → invoke context-save / context-restore
+- Code quality, health check → invoke health


### PR DESCRIPTION
## Summary
- Adds a "Skill routing" section to `CLAUDE.md` so Claude Code invokes the right gstack skill (investigate, ship, qa, review, retro, etc.) as a first action instead of answering ad-hoc.
- Uses the current skill names (`context-save` / `context-restore`, not the deprecated `checkpoint`).
- Documentation-only — no code changes.

## Test plan
- [ ] Confirm `CLAUDE.md` renders cleanly on GitHub.
- [ ] Next Claude Code session picks up the routing rules (no behavioral test needed beyond that).