### PR TITLE
feat(backup): add weekly Supabase DB backup workflow

### DIFF
--- a/.github/workflows/weekly-backup.yml
+++ b/.github/workflows/weekly-backup.yml
@@ -1,0 +1,83 @@
+name: Weekly Database Backup
+
+on:
+  schedule:
+    # Sundays at 09:00 UTC (02:00 PT) — low-traffic window
+    - cron: '0 9 * * 0'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: '20.x'
+  PNPM_VERSION: '10.11.1'
+  BUCKET: db-backups
+  RETENTION_WEEKS: '8'
+
+jobs:
+  backup:
+    name: Dump Supabase DB and upload to Storage
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install PostgreSQL 17 client
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-17
+          pg_dump --version
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run backup
+        env:
+          DIRECT_URL: ${{ secrets.SUPABASE_DIRECT_URL }}
+          DATABASE_URL: ${{ secrets.SUPABASE_DIRECT_URL }}
+        run: pnpm backup-db
+
+      - name: Upload dump + metadata to Supabase Storage
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          set -euo pipefail
+          WEEK=$(date -u +'%Y-W%V')
+          shopt -s nullglob
+          FILES=(backups/database/*.dump backups/database/*.metadata.json)
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "::error::No backup files found in backups/database/"
+            exit 1
+          fi
+          for f in "${FILES[@]}"; do
+            name=$(basename "$f")
+            echo "Uploading $name to ${BUCKET}/${WEEK}/${name}"
+            curl --fail-with-body -sS -X POST \
+              "${SUPABASE_URL}/storage/v1/object/${BUCKET}/${WEEK}/${name}" \
+              -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+              -H "Content-Type: application/octet-stream" \
+              -H "x-upsert: true" \
+              --data-binary @"$f"
+            echo
+          done
+
+      - name: Rotate old backups
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: node scripts/rotate-supabase-backups.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ production-monitoring-*.log
 # Claude
 .mcp.json
 .claude
+
+# gstack local artifacts (retros, checkpoints, etc.)
+.context/

--- a/scripts/rotate-supabase-backups.mjs
+++ b/scripts/rotate-supabase-backups.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Rotate weekly backup folders in Supabase Storage.
+// Keeps RETENTION_WEEKS most-recent week folders (YYYY-Www), deletes older ones.
+
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const bucket = process.env.BUCKET || 'db-backups';
+const keep = parseInt(process.env.RETENTION_WEEKS || '8', 10);
+
+if (!url || !key) {
+  throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+}
+
+const headers = {
+  Authorization: `Bearer ${key}`,
+  apikey: key,
+  'Content-Type': 'application/json',
+};
+
+async function listAt(prefix) {
+  const res = await fetch(`${url}/storage/v1/object/list/${bucket}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      prefix,
+      limit: 1000,
+      sortBy: { column: 'name', order: 'asc' },
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`List ${prefix || '/'} failed: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+const top = await listAt('');
+const weekFolders = [...new Set(top.map(e => e.name.split('/')[0]))]
+  .filter(n => /^\d{4}-W\d{2}$/.test(n))
+  .sort()
+  .reverse();
+
+const toDelete = weekFolders.slice(keep);
+console.log(
+  `Found ${weekFolders.length} week folders, keeping ${keep}, deleting ${toDelete.length}.`
+);
+
+for (const week of toDelete) {
+  const entries = await listAt(week);
+  const paths = entries.map(f => `${week}/${f.name}`);
+  if (paths.length === 0) continue;
+
+  const del = await fetch(`${url}/storage/v1/object/${bucket}`, {
+    method: 'DELETE',
+    headers,
+    body: JSON.stringify({ prefixes: paths }),
+  });
+  if (!del.ok) {
+    throw new Error(`Delete failed for ${week}: ${del.status} ${await del.text()}`);
+  }
+  console.log(`Deleted ${paths.length} files under ${week}/`);
+}
+
+console.log('Rotation complete.');


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that runs a weekly Supabase database backup
- Includes a rotation script to prune old backups
- Ignores local `.context/` snapshots from gstack retro

## Changes
- `.github/workflows/weekly-backup.yml` — scheduled weekly backup job
- `scripts/rotate-supabase-backups.mjs` — backup rotation/pruning helper
- `.gitignore` — exclude `.context/`

## Test plan
- [ ] Review workflow YAML for correct schedule, secrets, and permissions
- [ ] Manually trigger workflow via `workflow_dispatch` to verify backup runs end-to-end
- [ ] Confirm rotation script keeps the intended retention window
- [ ] Verify backup artifact/storage location is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)