### PR TITLE
fix(admin/sync): show all admin-triggered syncs in history view

### DIFF
--- a/src/__tests__/app/api/admin/sync-history.test.ts
+++ b/src/__tests__/app/api/admin/sync-history.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration tests for GET /api/admin/sync/history
+ *
+ * Verifies:
+ *  - Admins see syncs across all admins (no userId filter)
+ *  - Non-admins (defensive) only see their own syncs (userId filter retained)
+ *  - 401/403 short-circuit when verifyAdminAccess fails
+ *  - Response shape includes startedBy per row
+ */
+
+import { NextRequest } from 'next/server';
+
+const mockVerifyAdminAccess = jest.fn();
+const mockFindMany = jest.fn();
+const mockCount = jest.fn();
+const mockGroupBy = jest.fn();
+
+jest.mock('@/lib/auth/admin-guard', () => ({
+  verifyAdminAccess: (...args: unknown[]) => mockVerifyAdminAccess(...args),
+}));
+
+jest.mock('@/lib/db-unified', () => ({
+  prisma: {
+    userSyncLog: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+      count: (...args: unknown[]) => mockCount(...args),
+      groupBy: (...args: unknown[]) => mockGroupBy(...args),
+    },
+  },
+  withRetry: jest.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => Promise.resolve({ getAll: () => [] })),
+}));
+
+function createRequest(qs = ''): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/admin/sync/history${qs}`, {
+    method: 'GET',
+  });
+}
+
+describe('GET /api/admin/sync/history', () => {
+  let GET: (req: NextRequest) => Promise<Response>;
+
+  beforeAll(async () => {
+    ({ GET } = await import('@/app/api/admin/sync/history/route'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+    mockGroupBy.mockResolvedValue([]);
+  });
+
+  describe('auth gating', () => {
+    it('returns 401 when not authenticated', async () => {
+      mockVerifyAdminAccess.mockResolvedValue({
+        authorized: false,
+        error: 'Authentication required',
+        statusCode: 401,
+      });
+
+      const res = await GET(createRequest());
+      expect(res.status).toBe(401);
+      expect(mockFindMany).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when user is not admin', async () => {
+      mockVerifyAdminAccess.mockResolvedValue({
+        authorized: false,
+        error: 'Admin access required',
+        statusCode: 403,
+      });
+
+      const res = await GET(createRequest());
+      expect(res.status).toBe(403);
+      expect(mockFindMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cross-admin visibility', () => {
+    beforeEach(() => {
+      mockVerifyAdminAccess.mockResolvedValue({
+        authorized: true,
+        user: { id: 'admin-emmanuel', email: 'emmanuel@test.com', role: 'ADMIN' },
+      });
+    });
+
+    it('omits userId filter when role is ADMIN (list query)', async () => {
+      await GET(createRequest('?days=30&limit=10'));
+
+      expect(mockFindMany).toHaveBeenCalledTimes(1);
+      const callArgs = mockFindMany.mock.calls[0][0];
+      expect(callArgs.where).not.toHaveProperty('userId');
+      expect(callArgs.where.startTime).toBeDefined();
+    });
+
+    it('omits userId filter from totalSyncs count for ADMIN', async () => {
+      await GET(createRequest());
+
+      expect(mockCount).toHaveBeenCalledTimes(1);
+      const where = mockCount.mock.calls[0][0].where;
+      expect(where).not.toHaveProperty('userId');
+    });
+
+    it('omits userId filter from last7Days groupBy for ADMIN', async () => {
+      await GET(createRequest());
+
+      expect(mockGroupBy).toHaveBeenCalledTimes(1);
+      const where = mockGroupBy.mock.calls[0][0].where;
+      expect(where).not.toHaveProperty('userId');
+      expect(where.startTime).toBeDefined();
+    });
+
+    it('returns startedBy in formatted history rows', async () => {
+      mockFindMany.mockResolvedValue([
+        {
+          id: 'log-1',
+          syncId: 'sync-abc',
+          status: 'COMPLETED',
+          startTime: new Date('2026-04-25T00:45:00Z'),
+          endTime: new Date('2026-04-25T00:46:00Z'),
+          progress: 100,
+          message: 'Sync completed successfully - 116 items synced',
+          currentStep: null,
+          results: { syncedProducts: 116, skippedProducts: 0, warnings: 0, errors: 0 },
+          errors: null,
+          options: null,
+          startedBy: 'Emmanuel (emmanuel@alanis.dev)',
+        },
+      ]);
+      mockCount.mockResolvedValue(1);
+
+      const res = await GET(createRequest());
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.history).toHaveLength(1);
+      expect(body.history[0].startedBy).toBe('Emmanuel (emmanuel@alanis.dev)');
+    });
+  });
+
+  describe('non-admin defensive scoping', () => {
+    it('retains userId filter when role is CUSTOMER (defensive — route is admin-gated)', async () => {
+      // Hypothetical case: verifyAdminAccess returns authorized=true but role=CUSTOMER.
+      // The route's per-user fallback should engage so we never accidentally widen scope.
+      mockVerifyAdminAccess.mockResolvedValue({
+        authorized: true,
+        user: { id: 'customer-123', email: 'c@test.com', role: 'CUSTOMER' },
+      });
+
+      await GET(createRequest());
+
+      const listWhere = mockFindMany.mock.calls[0][0].where;
+      expect(listWhere.userId).toBe('customer-123');
+
+      const countWhere = mockCount.mock.calls[0][0].where;
+      expect(countWhere.userId).toBe('customer-123');
+
+      const groupByWhere = mockGroupBy.mock.calls[0][0].where;
+      expect(groupByWhere.userId).toBe('customer-123');
+    });
+  });
+});

--- a/src/__tests__/components/admin/SyncHistoryWithDetails.test.tsx
+++ b/src/__tests__/components/admin/SyncHistoryWithDetails.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SyncHistoryWithDetails } from '@/components/admin/sync/SyncHistoryWithDetails';
+
+jest.mock('lucide-react', () => {
+  const stub = ({ className }: { className?: string }) => (
+    <span className={className} data-testid="lucide-icon" />
+  );
+  return new Proxy(
+    {},
+    {
+      get: () => stub,
+    }
+  );
+});
+
+jest.mock('@/components/ui/badge', () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+jest.mock('@/components/ui/form/FormButton', () => ({
+  FormButton: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}));
+
+jest.mock('@/components/ui/form/FormStack', () => ({
+  FormStack: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('@/components/ui/form/FormIcons', () => ({
+  FormIcons: { refresh: <span /> },
+}));
+
+jest.mock('@/components/ui/ClientPagination', () => ({
+  ClientPagination: () => null,
+}));
+
+const buildResponse = (rows: unknown[]) => ({
+  history: rows,
+  pagination: { limit: 10, offset: 0, returned: rows.length, hasMore: false },
+  stats: { total: rows.length, last7Days: { completed: rows.length, failed: 0 } },
+});
+
+describe('<SyncHistoryWithDetails />', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders "No recent synchronizations" when API returns empty list', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => buildResponse([]),
+    });
+
+    render(<SyncHistoryWithDetails />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/No recent synchronizations/i)).toBeInTheDocument()
+    );
+  });
+
+  it('renders "Started by:" line when API returns rows with startedBy', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () =>
+        buildResponse([
+          {
+            syncId: 'sync-1',
+            status: 'COMPLETED',
+            startTime: '2026-04-25T00:45:00Z',
+            endTime: '2026-04-25T00:46:00Z',
+            duration: 60,
+            message: 'Sync completed successfully - 116 items synced',
+            startedBy: 'James (james@destinosf.com)',
+            summary: { syncedProducts: 116, skippedProducts: 0, warnings: 0, errors: 0 },
+          },
+        ]),
+    });
+
+    render(<SyncHistoryWithDetails />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Started by: James \(james@destinosf\.com\)/i)
+      ).toBeInTheDocument()
+    );
+  });
+
+  it('omits "Started by:" line when startedBy is missing', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () =>
+        buildResponse([
+          {
+            syncId: 'sync-2',
+            status: 'COMPLETED',
+            startTime: '2026-04-25T00:45:00Z',
+            duration: 60,
+            message: 'Sync completed',
+          },
+        ]),
+    });
+
+    render(<SyncHistoryWithDetails />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Sync completed/i)).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/Started by:/i)).not.toBeInTheDocument();
+  });
+
+  it('shows error state when API returns non-OK', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => 'boom',
+    });
+
+    render(<SyncHistoryWithDetails />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Error loading sync history/i)).toBeInTheDocument()
+    );
+  });
+});

--- a/src/app/api/admin/sync/history/route.ts
+++ b/src/app/api/admin/sync/history/route.ts
@@ -20,10 +20,12 @@ export async function GET(request: NextRequest) {
     const status = searchParams.get('status');
     const days = parseInt(searchParams.get('days') || '30'); // Last 30 days by default
 
+    // Admins see syncs across all admins; non-admins (defensive — route is already
+    // gated by verifyAdminAccess) only see their own.
+    const scopeWhere: any = user.role === 'ADMIN' ? {} : { userId: user.id };
+
     // 4. Build query filters
-    const where: any = {
-      userId: user.id,
-    };
+    const where: any = { ...scopeWhere };
 
     // Filter by status if provided
     if (status && ['PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED'].includes(status)) {
@@ -63,7 +65,7 @@ export async function GET(request: NextRequest) {
 
     // 6. Calculate summary statistics
     const totalSyncs = await prisma.userSyncLog.count({
-      where: { userId: user.id },
+      where: scopeWhere,
     });
 
     const last7Days = new Date();
@@ -72,7 +74,7 @@ export async function GET(request: NextRequest) {
     const recentStats = await prisma.userSyncLog.groupBy({
       by: ['status'],
       where: {
-        userId: user.id,
+        ...scopeWhere,
         startTime: {
           gte: last7Days,
         },

--- a/src/components/admin/sync/SyncHistoryWithDetails.tsx
+++ b/src/components/admin/sync/SyncHistoryWithDetails.tsx
@@ -44,6 +44,7 @@ interface SyncRecord {
   endTime?: string;
   duration?: number;
   message?: string;
+  startedBy?: string;
   summary?: {
     syncedProducts: number;
     skippedProducts: number;
@@ -434,6 +435,11 @@ export function SyncHistoryWithDetails({ refreshTrigger }: SyncHistoryProps) {
                     <div className="space-y-1">
                       {record.message && (
                         <div className="text-sm text-gray-600">{record.message}</div>
+                      )}
+                      {record.startedBy && (
+                        <div className="text-xs text-gray-500 font-medium">
+                          Started by: {record.startedBy}
+                        </div>
                       )}
                       {record.duration && (
                         <div className="text-xs text-gray-500 font-medium">

--- a/tests/e2e/19-admin-sync-history.spec.ts
+++ b/tests/e2e/19-admin-sync-history.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * E2E: Admin Square Sync History
+ *
+ * Verifies the cross-admin history view:
+ *  - Admins can reach /admin/square-sync
+ *  - The Synchronization History section renders
+ *  - The history API returns rows whose payload includes a `startedBy` field
+ *    (so the UI can label who triggered each sync)
+ *  - Customers and unauthenticated users are denied
+ *
+ * The seed dataset is environment-specific, so tests assert on shape rather
+ * than concrete sync counts.
+ */
+
+import { test, expect } from '@playwright/test';
+import { AuthHelpers } from './utils/auth-helpers';
+
+test.describe('Admin Square Sync — history view', () => {
+  test('admin can open the sync page and history section is rendered', async ({ page }) => {
+    await AuthHelpers.loginAsAdmin(page);
+    await page.goto('/admin/square-sync');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/\/admin\/square-sync/);
+    await expect(
+      page.getByRole('heading', { name: /Square Synchronization/i })
+    ).toBeVisible();
+    await expect(page.getByText(/Synchronization History/i)).toBeVisible();
+  });
+
+  test('history API returns startedBy field for admin requests', async ({ page }) => {
+    await AuthHelpers.loginAsAdmin(page);
+
+    const response = await page.request.get(
+      '/api/admin/sync/history?days=30&limit=10'
+    );
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(Array.isArray(body.history)).toBe(true);
+
+    // If the env has any sync rows, every row should expose startedBy so the
+    // UI can render "Started by: …". Empty environments are acceptable.
+    for (const row of body.history) {
+      expect(row).toHaveProperty('startedBy');
+    }
+  });
+
+  test('customer cannot reach the admin sync page', async ({ page }) => {
+    await AuthHelpers.loginAsCustomer(page);
+    await page.goto('/admin/square-sync');
+    await expect(page).not.toHaveURL(/\/admin\/square-sync$/);
+  });
+
+  test('unauthenticated user is redirected to sign-in', async ({ page }) => {
+    await AuthHelpers.ensureLoggedOut(page);
+    await page.goto('/admin/square-sync');
+    await expect(page).toHaveURL(/\/(auth\/)?sign-in/);
+  });
+});


### PR DESCRIPTION
## Summary

Admins now see every admin-triggered Square sync in the history panel, not just their own. Each row labels the sync with who started it.

- API: when `user.role === 'ADMIN'`, drop the `userId` filter on the history list, count, and last-7-days groupBy queries (`src/app/api/admin/sync/history/route.ts`). Non-admins (defensive — route is already gated by `verifyAdminAccess`) keep per-user scoping.
- UI: surface the existing `startedBy` field per row in `SyncHistoryWithDetails.tsx`.

### Why

There are two active admin users in prod. The history view filtered by the requesting admin's `userId`, so the panel rendered "No recent synchronizations" whenever the viewer hadn't personally triggered the latest sync — even though the underlying `user_sync_logs` table had 52 rows. Sync history is more useful as a shared operational log.

### Out of scope (intentional)

`/api/admin/sync/status/[syncId]`, `/api/admin/sync/cancel`, and the trigger rate-limit/active-sync guard remain per-user. Discuss broadening those in a follow-up if cross-admin operability becomes painful.

## Test plan

- [ ] Type-check passes (`pnpm type-check`)
- [ ] Lint clean on changed files (`pnpm lint`)
- [ ] Vercel preview build green
- [ ] On preview, log in as `emmanuel@alanis.dev` → `/admin/square-sync` shows recent syncs from both admins, each with a "Started by:" line
- [ ] Same view as `james@destinosf.com` shows the same list (length parity)
- [ ] CUSTOMER-role user still gets 401/403 on `/api/admin/sync/history` (auth guard unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)