### PR TITLE
chore(security): weekly pnpm audit workflow + Q2 baseline

### DIFF
--- a/.github/workflows/weekly-security-audit.yml
+++ b/.github/workflows/weekly-security-audit.yml
@@ -1,0 +1,175 @@
+name: Weekly Security Audit
+
+on:
+  schedule:
+    # Mondays at 13:00 UTC (06:00 PT) — fresh week, before standup
+    - cron: '0 13 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  NODE_VERSION: '20.x'
+  PNPM_VERSION: '10.17.1'
+
+jobs:
+  audit:
+    name: pnpm audit --prod and triage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Install dependencies (audit needs the full lockfile graph)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Run pnpm audit --prod
+        id: audit
+        run: |
+          set +e
+          pnpm audit --prod --json > audit.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+          # `pnpm audit` exits non-zero when vulnerabilities are found; that is expected, not a step failure.
+
+      - name: Summarize advisories
+        id: summary
+        run: |
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('fs');
+          const raw = fs.readFileSync('audit.json', 'utf8');
+          let parsed;
+          try {
+            parsed = JSON.parse(raw);
+          } catch (err) {
+            console.error('Failed to parse audit.json:', err.message);
+            process.exit(1);
+          }
+          const advisories = parsed.advisories || {};
+          const counts = { critical: 0, high: 0, moderate: 0, low: 0, info: 0 };
+          const highSeverity = [];
+          for (const a of Object.values(advisories)) {
+            counts[a.severity] = (counts[a.severity] || 0) + 1;
+            if (a.severity === 'high' || a.severity === 'critical') {
+              highSeverity.push({
+                severity: a.severity,
+                module: a.module_name,
+                vulnerable_versions: a.vulnerable_versions,
+                patched_versions: a.patched_versions,
+                title: a.title,
+                url: a.url,
+              });
+            }
+          }
+          const total = Object.values(counts).reduce((a, b) => a + b, 0);
+          fs.writeFileSync('audit-summary.json', JSON.stringify({ counts, total, highSeverity }, null, 2));
+          // Emit values for the next step
+          console.log(`total=${total}`);
+          console.log(`critical=${counts.critical}`);
+          console.log(`high=${counts.high}`);
+          console.log(`moderate=${counts.moderate}`);
+          console.log(`low=${counts.low}`);
+          NODE
+
+      - name: Upload audit artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pnpm-audit-${{ github.run_id }}
+          path: |
+            audit.json
+            audit-summary.json
+          retention-days: 90
+
+      - name: Open or update tracking issue if highs are present
+        if: steps.summary.outputs.high != '0' || steps.summary.outputs.critical != '0'
+        uses: actions/github-script@v7
+        env:
+          AUDIT_TOTAL: ${{ steps.summary.outputs.total }}
+          AUDIT_CRITICAL: ${{ steps.summary.outputs.critical }}
+          AUDIT_HIGH: ${{ steps.summary.outputs.high }}
+          AUDIT_MODERATE: ${{ steps.summary.outputs.moderate }}
+          AUDIT_LOW: ${{ steps.summary.outputs.low }}
+        with:
+          script: |
+            const fs = require('fs');
+            const summary = JSON.parse(fs.readFileSync('audit-summary.json', 'utf8'));
+            const today = new Date().toISOString().slice(0, 10);
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+            const lines = [];
+            lines.push(`**Audit run:** [${today}](${runUrl})`);
+            lines.push('');
+            lines.push('| Severity | Count |');
+            lines.push('|----------|-------|');
+            lines.push(`| Critical | ${process.env.AUDIT_CRITICAL} |`);
+            lines.push(`| High     | ${process.env.AUDIT_HIGH} |`);
+            lines.push(`| Moderate | ${process.env.AUDIT_MODERATE} |`);
+            lines.push(`| Low      | ${process.env.AUDIT_LOW} |`);
+            lines.push(`| **Total** | **${process.env.AUDIT_TOTAL}** |`);
+            lines.push('');
+            lines.push('### High / critical advisories');
+            lines.push('');
+            for (const a of summary.highSeverity) {
+              lines.push(`- **[${a.severity.toUpperCase()}] ${a.module}** ${a.vulnerable_versions} → patched in ${a.patched_versions}`);
+              lines.push(`  ${a.title}`);
+              lines.push(`  ${a.url}`);
+            }
+            lines.push('');
+            lines.push('Triage owner: assign to whoever picks this up. Close once `pnpm audit --prod` reports 0 high.');
+
+            const body = lines.join('\n');
+            const title = `Weekly security audit — ${today} (${process.env.AUDIT_HIGH} high, ${process.env.AUDIT_CRITICAL} critical)`;
+
+            // Find an existing open audit-tracking issue; update it instead of opening a new one each week.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security-audit',
+              per_page: 10,
+            });
+
+            if (existing.data.length > 0) {
+              const issue = existing.data[0];
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                title,
+                body,
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Updated by [${today} run](${runUrl}). Highs: ${process.env.AUDIT_HIGH}, criticals: ${process.env.AUDIT_CRITICAL}.`,
+              });
+              core.notice(`Updated existing issue #${issue.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['security-audit', 'priority:high'],
+              });
+              core.notice(`Opened issue #${created.data.number}`);
+            }
+
+      - name: Note when audit is clean
+        if: steps.summary.outputs.high == '0' && steps.summary.outputs.critical == '0'
+        run: |
+          echo "::notice::pnpm audit --prod reported 0 high/critical advisories. Total: ${{ steps.summary.outputs.total }}."

--- a/docs/ROADMAP_2026_Q2_DEFERRED.md
+++ b/docs/ROADMAP_2026_Q2_DEFERRED.md
@@ -1,7 +1,7 @@
 # Destino SF — Q2 2026 Deferred Items + Master Maintenance Audit Plan
 
 **Created:** 2026-04-03
-**Last reviewed:** 2026-04-20
+**Last reviewed:** 2026-05-03
 **Based on:** [Q2 2026 Roadmap](./ROADMAP_2026_Q2.md) (deferred items)
 **Goal:** Complete all deferred items from the Q2 audit and establish a recurring maintenance framework.
 **Timeline:** ~12 weeks (6 sprints of 1-2 weeks each)
@@ -18,7 +18,7 @@
 | Sprint 4 — Test Expansion | 🔴 Not started | E2E specs 17/18 not created; `collectCoverage` still `false`; `todo-triage.md` missing. |
 | Sprint 5 — Observability | 🟡 Partial | **Weekly DB backup shipped (PR #148)** — new. Prisma slow-query logging + `check-bundle-size.ts` still pending. |
 | Sprint 6 — Finalization | 🔴 Not started | No Lighthouse thresholds, no `MAINTENANCE_AUDIT_PLAN.md`. |
-| Sprint 7 — Security & Dep Hygiene | 🔴 Not started | **Newly added 2026-04-20.** 52 prod vulns (26 high) + 78 outdated deps uncovered; scripts/ inventory pending. |
+| Sprint 7 — Security & Dep Hygiene | 🟡 In progress | **Newly added 2026-04-20.** 7.1 weekly audit workflow + baseline doc shipped 2026-05-03; 26 highs still open. 7.2-7.4 not started. |
 
 **Next quick wins (≤2h each):**
 1. Flip `collectCoverage` to `process.env.CI === 'true'` (Sprint 4.2)
@@ -172,13 +172,16 @@ Tests live in `src/__tests__/app/api/admin/admin-crud.test.ts`:
 
 Discovered during 2026-04-20 audit. **Not in original plan.**
 
-### 7.1 Production Security Vulnerabilities — 🔴 Urgent
+### 7.1 Production Security Vulnerabilities — 🟡 In progress
 Baseline from `pnpm audit --prod` on 2026-04-20: **52 vulns (26 high, 22 moderate, 4 low)**.
-- [ ] Triage all 26 high-severity advisories; file one tracking issue per advisory or per transitive dep
-- [ ] Patch direct deps where newer versions resolve advisories (e.g. `qs` via `square` SDK)
-- [ ] For transitive vulns with no upstream fix, document accepted risk in `docs/security/accepted-risks.md`
-- [ ] Add `.github/workflows/security-audit.yml` — run `pnpm audit --prod` weekly, open issue on new highs
-- [ ] **Verify:** `pnpm audit --prod` reports 0 high severity
+Re-baseline on 2026-05-03: **57 vulns (26 high, 27 moderate, 4 low)** — see [`docs/security/2026-Q2-audit-baseline.md`](./security/2026-Q2-audit-baseline.md).
+- [x] **2026-05-03:** Captured baseline of 26 highs across 13 modules with direct/transitive classification and triage suggestions.
+- [x] **2026-05-03:** Added `.github/workflows/weekly-security-audit.yml` — runs `pnpm audit --prod` Mondays at 13:00 UTC, opens or updates a `security-audit`-labeled tracking issue when highs are present, and uploads `audit.json` as an artifact.
+- [ ] Bump `next` to `>=15.5.15` (direct dep, kills 2 highs).
+- [ ] Resolve `react-email` / `jest-watch-typeahead` placement — move to devDependencies if confirmed unused at runtime (drops ~7 highs from `--prod`).
+- [ ] `@sentry/nextjs` upgrade — check changelog for a release that bundles current rollup/picomatch/serialize-javascript.
+- [ ] For transitive vulns with no upstream fix, document accepted risk in `docs/security/accepted-risks.md`.
+- [ ] **Verify:** `pnpm audit --prod` reports 0 high severity.
 
 ### 7.2 Dependency Freshness — 🔴 Not started
 Baseline: **78 outdated packages** on 2026-04-20. Notable majors pending: `zustand`, `@tanstack/react-query`, `@supabase/supabase-js`, `framer-motion`, `@playwright/test`.
@@ -194,8 +197,8 @@ Current count: **131 files** — heavy concentration of one-off `fix-*`, `debug-
 - [ ] Document retention policy: deletion after N days or after incident closeout
 
 ### 7.4 Automation Coverage
-Currently only 1 scheduled workflow (`weekly-backup.yml`). Candidates:
-- [ ] `weekly-security-audit.yml` — see 7.1
+Currently 2 scheduled workflows (`weekly-backup.yml`, `weekly-security-audit.yml`). Candidates:
+- [x] `weekly-security-audit.yml` — shipped 2026-05-03 (see 7.1)
 - [ ] `weekly-dep-report.yml` — see 7.2
 - [ ] `stale-branch-cleanup.yml` — delete merged remote branches older than 30 days
 
@@ -275,6 +278,6 @@ Currently only 1 scheduled workflow (`weekly-backup.yml`). Candidates:
 | Sprint 4: Test Expansion | **Not Started** | — | 0% |
 | Sprint 5: Observability | **In Progress** | — | ~25% (5.0 weekly backup done; 5.1/5.2 pending; 5.3 partial) |
 | Sprint 6: Maintenance | **Not Started** | — | 0% |
-| Sprint 7: Security & Dep Hygiene | **Not Started** | — | 0% (added 2026-04-20) |
+| Sprint 7: Security & Dep Hygiene | **In Progress** | — | 7.1 partial (workflow + baseline shipped 2026-05-03); 7.2-7.4 not started |
 
 _Last updated: 2026-04-20_

--- a/docs/security/2026-Q2-audit-baseline.md
+++ b/docs/security/2026-Q2-audit-baseline.md
@@ -1,0 +1,157 @@
+# Q2 2026 Security Audit Baseline
+
+**Generated:** 2026-05-03 from `pnpm audit --prod --json`
+**Scope:** production dependencies only (devDependencies excluded)
+**Roadmap link:** [`docs/ROADMAP_2026_Q2_DEFERRED.md`](../ROADMAP_2026_Q2_DEFERRED.md) — Sprint 7.1
+
+This document is the **starting state** of the production vulnerability backlog as of the date above. The new `.github/workflows/weekly-security-audit.yml` will keep an open issue tagged `security-audit` updated against this baseline. When `pnpm audit --prod` reports zero high/critical, the workflow goes silent and we can retire this doc.
+
+## Severity totals
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High     | 26 |
+| Moderate | 27 |
+| Low      | 4 |
+| **Total** | **57** |
+
+26 high-severity advisories span **13 unique modules**. Most are transitive — addressed only by upgrading the parent package or adding a pnpm override.
+
+## Triage classification
+
+### Direct dep, patch available — fix this week
+
+| Module | Current vuln range | Patched in | Action |
+|--------|--------------------|------------|--------|
+| `next` | `>=13.0.0 <15.5.15` (and `>=15.5.1-canary.0 <15.5.10`) | `>=15.5.15` | Bump `next` to `15.5.15+`. Rebuild, run full E2E. Two GHSAs collapse into one upgrade. |
+
+### Transitive, parent owns the fix — file upstream / wait for next release
+
+| Module | Path (one example) | Patched in | Owner package | Notes |
+|--------|---------------------|------------|---------------|-------|
+| `axios` | `.>square>square>@apimatic/axios-client-adapter>axios` | `>=1.13.5` | `square` SDK | Square SDK pins an older axios. File issue or wait for SDK release. Prototype-pollution DoS. |
+| `valibot` | `.>@t3-oss/env-core>valibot` | `>=1.2.0` | `@t3-oss/env-core` | ReDoS in EMOJI_REGEX. Low real-world reach. |
+| `effect`, `defu` | `.>@prisma/client>prisma>@prisma/config>...` | `>=3.20.0` / `>=6.1.5` | `prisma` | Prisma config internals. Bump prisma when 6.x lands a patched build. |
+| `playwright` | `.>next>@playwright/test>playwright` | `>=1.55.1` | `next` | Even though we don't ship Playwright to prod, it appears in the prod graph via `next`'s peer-friendly install. Watch for next minor that bumps it. |
+| `rollup`, `picomatch`, `serialize-javascript`, `minimatch` | `.>@sentry/nextjs>...` | various | `@sentry/nextjs` | Sentry's webpack-plugin pulls a vintage rollup. Sentry usually bundles its own; check if a `@sentry/nextjs` upgrade resolves all four at once before adding overrides. |
+| `socket.io-parser`, `glob`, `@isaacs/brace-expansion`, `minimatch` | `.>react-email>...` | various | `react-email` | react-email pulls in socket.io for its preview server. We do not run that server in production builds, but it shows up in the prod graph. Either upgrade `react-email`, or move it to devDependencies if confirmed unused at runtime. |
+| `picomatch`, `minimatch` | `.>jest-watch-typeahead>jest>...` | various | jest | This appears under `--prod` because of how the lockfile is structured; jest is a devDep. Verify with `pnpm why jest-watch-typeahead`. If only devDep, ignore. |
+
+### Acceptance candidates (low real-world impact)
+
+The minimatch / picomatch / brace-expansion ReDoS family is reachable only when an attacker controls a glob pattern compiled at runtime. Our code does not feed user input into these. They will close out automatically when the parents above are upgraded; no manual mitigation needed.
+
+## Per-module advisory list (verbatim from `pnpm audit`)
+
+### @isaacs/brace-expansion
+
+- **[HIGH]** `<=5.0.0` → patched in `>=5.0.1`
+  - @isaacs/brace-expansion has Uncontrolled Resource Consumption
+  - CWE: CWE-1333
+  - https://github.com/advisories/GHSA-7h2j-956f-4vf2
+
+### axios
+
+- **[HIGH]** `>=1.0.0 <=1.13.4` → patched in `>=1.13.5`
+  - Axios is Vulnerable to Denial of Service via __proto__ Key in mergeConfig
+  - CWE: CWE-754
+  - https://github.com/advisories/GHSA-43fc-jf86-j433
+
+### defu
+
+- **[HIGH]** `<=6.1.4` → patched in `>=6.1.5`
+  - defu: Prototype pollution via `__proto__` key in defaults argument
+  - CWE: CWE-1321
+  - https://github.com/advisories/GHSA-737v-mqg7-c878
+
+### effect
+
+- **[HIGH]** `<3.20.0` → patched in `>=3.20.0`
+  - Effect AsyncLocalStorage context lost/contaminated inside Effect fibers under concurrent load with RPC
+  - CWE: CWE-362
+  - https://github.com/advisories/GHSA-38f7-945m-qr2g
+
+### glob
+
+- **[HIGH]** `>=11.0.0 <11.1.0` → patched in `>=11.1.0`
+  - glob CLI: Command injection via -c/--cmd executes matches with shell:true
+  - CWE: CWE-78
+  - https://github.com/advisories/GHSA-5j98-mcp5-4vw2
+
+### minimatch (4 advisory ranges, all ReDoS variants)
+
+- **[HIGH]** `<3.1.3` → patched in `>=3.1.3` — repeated wildcards (CWE-1333) — https://github.com/advisories/GHSA-3ppc-4f35-3m26
+- **[HIGH]** `>=8.0.0 <8.0.5` → patched in `>=8.0.5` — repeated wildcards
+- **[HIGH]** `>=9.0.0 <9.0.6` → patched in `>=9.0.6` — repeated wildcards
+- **[HIGH]** `>=10.0.0 <10.2.1` → patched in `>=10.2.1` — repeated wildcards
+- **[HIGH]** `<3.1.3` → patched in `>=3.1.3` — matchOne combinatorial backtracking (CWE-407) — https://github.com/advisories/GHSA-7r86-cg39-jmmj
+- **[HIGH]** `>=8.0.0 <8.0.6` → patched in `>=8.0.6` — matchOne combinatorial backtracking
+- **[HIGH]** `>=9.0.0 <9.0.7` → patched in `>=9.0.7` — matchOne combinatorial backtracking
+- **[HIGH]** `>=10.0.0 <10.2.3` → patched in `>=10.2.3` — matchOne combinatorial backtracking
+- **[HIGH]** `<3.1.4` → patched in `>=3.1.4` — nested *() extglobs (CWE-1333) — https://github.com/advisories/GHSA-23c5-xmqv-rm74
+- **[HIGH]** `>=8.0.0 <8.0.6` → patched in `>=8.0.6` — nested *() extglobs
+- **[HIGH]** `>=9.0.0 <9.0.7` → patched in `>=9.0.7` — nested *() extglobs
+- **[HIGH]** `>=10.0.0 <10.2.3` → patched in `>=10.2.3` — nested *() extglobs
+
+### next
+
+- **[HIGH]** `>=15.5.1-canary.0 <15.5.10` → patched in `>=15.5.10`
+  - Next.js HTTP request deserialization can lead to DoS when using insecure React Server Components
+  - CWE: CWE-400, CWE-502
+  - https://github.com/advisories/GHSA-h25m-26qc-wcjf
+- **[HIGH]** `>=13.0.0 <15.5.15` → patched in `>=15.5.15`
+  - Next.js has a Denial of Service with Server Components
+  - CWE: CWE-770
+  - https://github.com/advisories/GHSA-q4gf-8mx6-v5v3
+
+### picomatch
+
+- **[HIGH]** `<2.3.2` → patched in `>=2.3.2`
+  - Picomatch has a ReDoS vulnerability via extglob quantifiers
+  - CWE: CWE-1333
+  - https://github.com/advisories/GHSA-c2c7-rcm5-vvqj
+- **[HIGH]** `>=4.0.0 <4.0.4` → patched in `>=4.0.4` (same advisory)
+
+### playwright
+
+- **[HIGH]** `<1.55.1` → patched in `>=1.55.1`
+  - Playwright downloads and installs browsers without verifying the authenticity of the SSL certificate
+  - CWE: CWE-347
+  - https://github.com/advisories/GHSA-7mvr-c777-76hp
+
+### rollup
+
+- **[HIGH]** `>=4.0.0 <4.59.0` → patched in `>=4.59.0`
+  - Rollup 4 has Arbitrary File Write via Path Traversal
+  - CWE: CWE-22
+  - https://github.com/advisories/GHSA-mw96-cpmx-2vgc
+
+### serialize-javascript
+
+- **[HIGH]** `<=7.0.2` → patched in `>=7.0.3`
+  - Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString()
+  - CWE: CWE-96
+  - https://github.com/advisories/GHSA-5c6j-r48x-rmvq
+
+### socket.io-parser
+
+- **[HIGH]** `>=4.0.0 <4.2.6` → patched in `>=4.2.6`
+  - socket.io allows an unbounded number of binary attachments
+  - CWE: CWE-754
+  - https://github.com/advisories/GHSA-677m-j7p3-52f9
+
+### valibot
+
+- **[HIGH]** `>=0.31.0 <1.2.0` → patched in `>=1.2.0`
+  - Valibot has a ReDoS vulnerability in `EMOJI_REGEX`
+  - CWE: CWE-1333
+  - https://github.com/advisories/GHSA-vqpr-j7v3-hqw9
+
+## Suggested next steps (in order)
+
+1. **Bump `next` to `15.5.15+`** — direct dep, single PR, kills two GHSAs.
+2. **`pnpm why react-email` and `pnpm why jest-watch-typeahead`** — confirm whether these belong in dependencies or devDependencies. Moving to dev would drop ~7 of the high advisories from `--prod` immediately.
+3. **`@sentry/nextjs` upgrade** — check the changelog for one that bundles a current rollup/picomatch/serialize-javascript. Single bump, four advisories close.
+4. **Set up Dependabot/Renovate** (Sprint 7.2) so the prisma / square / t3-oss upstream fixes land here automatically when published.
+5. **Add `accepted-risks.md`** for any advisory that survives the above passes after we've confirmed no exploitable path in our code.


### PR DESCRIPTION
## Summary

Sprint 7.1 starter from `docs/ROADMAP_2026_Q2_DEFERRED.md`. Adds the recurring scaffolding so the 26 high-severity production advisories stop being a snapshot in a roadmap doc and start being a live tracking issue we can chip away at.

### What's in this PR

- **`.github/workflows/weekly-security-audit.yml`** — runs `pnpm audit --prod` every Monday at 13:00 UTC (also `workflow_dispatch`). When highs or criticals are present, opens or updates a single issue labeled `security-audit` with severity totals + advisory details + a link to the uploaded `audit.json` artifact. Stays silent when audit is clean.
- **`docs/security/2026-Q2-audit-baseline.md`** — one-shot triage doc: today's 26 highs grouped by module, classified direct vs. transitive, with a concrete next-step list (`next` bump kills 2; sentry/react-email/jest parents own most of the rest).
- **`docs/ROADMAP_2026_Q2_DEFERRED.md`** — status snapshot updated. Sprint 7.1 moves 🔴 Not started → 🟡 In progress; 7.4 marks the security workflow shipped.

### Why now

Sprint 7 was the only roadmap item flagged 🔴 **Urgent** and untouched since 2026-04-20. Workflow + baseline doc are low-blast-radius and unblock everything else in 7.1 (`next` bump, dep moves, override decisions). Pairs naturally with Sprint 7.2 (Dependabot) as a follow-up.

### Verification

- `python3` YAML parse + key/structure check on the workflow file (no tabs, top-level `on`/`jobs`/`permissions` present, `actions/github-script@v7` ref correct).
- Local re-run of `pnpm audit --prod --json`: **57 advisories total** — 26 high / 27 moderate / 4 low. Matches the roadmap's 2026-04-20 high count exactly; moderate count drifted by 5.
- Workflow needs only the standard `GITHUB_TOKEN` (`issues: write` permission). No new secrets.
- Will be exercised end-to-end on merge: a `workflow_dispatch` run will produce the first tracked issue.

## Test plan

- [x] Workflow YAML parses cleanly
- [x] Audit reproduces locally (26 highs, 13 unique modules)
- [x] Roadmap status updated and consistent across the snapshot table, Sprint 7.1, and Sprint 7.4
- [ ] Post-merge: trigger `workflow_dispatch` once, confirm a `security-audit`-labeled issue appears
- [ ] Post-merge: confirm the artifact upload (`audit.json`) is downloadable from the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)