### PR TITLE
chore: ignore supabase CLI local cache (.temp/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ production-monitoring-*.log
 prod_dump.dump
 prod_*.sql
 .gstack/
+
+# supabase CLI local cache (project-ref, service versions, pooler url)
+supabase/.temp/


### PR DESCRIPTION
## Summary
- Add `supabase/.temp/` to `.gitignore`. This dir is created by the Supabase CLI when you run `supabase link` / `supabase db ...` and holds local-only metadata (project-ref, service versions, pooler URL). It regenerates on the next CLI invocation and should never be committed.

## Test plan
- [x] `git status` no longer reports `supabase/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)