### PR TITLE
fix(checkout): reject stale product IDs with a clear error instead of FK crash

### DIFF
--- a/src/app/actions/orders.ts
+++ b/src/app/actions/orders.ts
@@ -619,6 +619,26 @@ export async function createOrderAndGenerateCheckoutUrl(formData: {
   // Create a map for quick lookup
   const productMap = new Map(productsWithCategories.map(p => [p.id, p]));
 
+  // Guard: every cart productId must exist in the products table, otherwise
+  // prisma.order.create will throw a P2003 FK violation on order_items_productId_fkey.
+  // Most common cause: client cart (Zustand + localStorage) carries IDs for products
+  // that were since removed by a Square sync.
+  const missingProductIds = productIds.filter(id => !productMap.has(id));
+  if (missingProductIds.length > 0) {
+    console.error('[Checkout] Cart contains stale product IDs', {
+      missingProductIds,
+      email: customerInfo.email,
+      userId: supabaseUserId,
+    });
+    return {
+      success: false,
+      error:
+        'Some items in your cart are no longer available. Please refresh the page and remove them from your cart, then try again.',
+      checkoutUrl: null,
+      orderId: null,
+    };
+  }
+
   const orderItemsData = items.map(item => {
     const itemPrice = new Decimal(item.price);
     const itemTotal = itemPrice.times(item.quantity);
@@ -1297,6 +1317,23 @@ export async function createManualPaymentOrder(formData: {
 
   // Create a map for quick lookup
   const productMap = new Map(productsWithCategories.map(p => [p.id, p]));
+
+  // Guard: every cart productId must exist in the products table; see equivalent
+  // guard in createOrderAndGenerateCheckoutUrl.
+  const missingProductIds = productIds.filter(id => !productMap.has(id));
+  if (missingProductIds.length > 0) {
+    console.error('[Checkout] Cart contains stale product IDs (manual payment)', {
+      missingProductIds,
+      email: customerInfo.email,
+    });
+    return {
+      success: false,
+      error:
+        'Some items in your cart are no longer available. Please refresh the page and remove them from your cart, then try again.',
+      checkoutUrl: null,
+      orderId: null,
+    };
+  }
 
   const orderItemsData = items.map(item => {
     const itemPrice = new Decimal(item.price);

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -117,17 +117,47 @@ export async function POST(request: Request) {
         );
       }
 
-      // Get product information from Sanity or database
-      // This is simplified for this example
+      // Look up real product prices from the DB. The cart only carries id + quantity;
+      // trusting client-supplied prices would let an attacker self-discount, and
+      // referencing a non-existent productId would trip the order_items_productId_fkey
+      // constraint at insert time.
+      const productIds = items.map(item => item.id);
+      const products = await prisma.product.findMany({
+        where: { id: { in: productIds } },
+        select: { id: true, price: true },
+      });
+      const productPriceMap = new Map(products.map(p => [p.id, p.price]));
+
+      const missingProductIds = productIds.filter(id => !productPriceMap.has(id));
+      if (missingProductIds.length > 0) {
+        console.error('[Checkout API] Cart contains stale product IDs', {
+          missingProductIds,
+          email: customerInfo.email,
+          userId: user?.id,
+        });
+        return NextResponse.json(
+          {
+            error: 'Stale cart',
+            message:
+              'Some items in your cart are no longer available. Please refresh the page and remove them from your cart, then try again.',
+            staleProductIds: missingProductIds,
+          },
+          { status: 409 }
+        );
+      }
+
       const orderItems = items.map(item => ({
         productId: item.id,
         variantId: item.variantId,
         quantity: item.quantity,
-        price: 0, // You'd calculate this based on your actual product data
+        price: productPriceMap.get(item.id)!,
       }));
 
-      // Calculate total
-      const total = orderItems.reduce((sum, item) => sum + item.price * item.quantity, 0);
+      // Calculate total from the DB prices we just resolved.
+      const total = orderItems.reduce(
+        (sum, item) => sum + Number(item.price) * item.quantity,
+        0
+      );
 
       // Create order in database with connection management and idempotency
       let order;


### PR DESCRIPTION
## Problem

Sentry has been collecting `Foreign key constraint violated on the constraint: order_items_productId_fkey` events from `/checkout` when customers click **Continue to Payment** ([Sentry: DESTINO-SF-C, DESTINO-SF-9, DESTINO-SF-3](https://github.com/ReadySet1/destino-sf/issues)). The customer sees a failed checkout with no actionable message.

**Root cause:** `createOrderAndGenerateCheckoutUrl` (and the cash-payment variant `createManualPaymentOrder`) builds `orderItemsData` from cart items and feeds them straight into `prisma.order.create({ items: { create: ... } })`. The action does fetch matching products (for tax category lookup), but never validates that every cart `item.id` actually came back from the DB. When the cart contains a productId that was removed by a Square sync — common after seasonal/menu changes — the FK fires.

## Fix

Right after the existing `prisma.product.findMany` (lines ~614 and ~1294 in `src/app/actions/orders.ts`), check that every requested productId is present in the result. If not:

- Log the missing IDs (so we can correlate with `sync_logs`).
- Return a structured `ServerActionResult` with `success: false` and a customer-facing message:
  > Some items in your cart are no longer available. Please refresh the page and remove them from your cart, then try again.

Applied in three places:

1. **`createOrderAndGenerateCheckoutUrl`** — primary checkout path (the one CheckoutForm calls).
2. **`createManualPaymentOrder`** — cash-only variant.
3. **`POST /api/checkout`** — legacy/public API route. While there I also fixed the long-standing `price: 0` TODO: the route now reads canonical prices from the DB instead of trusting client-supplied prices (which would let an attacker self-discount).

No schema, dep, or build-tooling changes.

## Test plan
- [x] `pnpm type-check` — clean
- [x] `pnpm build` — clean
- [ ] Manual: place an order with a known-stale productId in the cart on the preview deploy → expect the new 409 / friendly message, not the FK crash.
- [ ] Sentry: confirm event volume on `prisma.order.create > FK violation > order_items_productId_fkey` drops to zero in the 24h after merge.

## Follow-ups (not in this PR)
1. **Client-side cart hygiene:** add a lightweight `/api/products/exists?ids=…` endpoint and prune stale IDs from `useCartStore` on hydrate, so customers don't reach checkout with bad state in the first place.
2. **Test coverage:** `describe.skip('createOrderAndGenerateCheckoutUrl')` in `orders-comprehensive.test.ts` means the whole action has no running jest coverage today. Worth unskipping and adding a regression test for this guard — it'll need mocks for auth, `isStoreOpen`, `validateOrderMinimums`, `hasCateringProducts`.
3. **Separate Sentry issue:** the same screenshot also showed `PrismaClientInitializationError: Can't reach database server at aws-0-us-west-1.pooler.supabase.com:6543` and `circuit breaker is OPEN`. Those are pooler/connection-resilience issues, **unrelated to this fix** — should be triaged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)