### PR TITLE
fix(db): shorten pool_timeout, raise connection_limit, skip client teardown on P2024

### DIFF
--- a/src/__tests__/lib/db-unified.test.ts
+++ b/src/__tests__/lib/db-unified.test.ts
@@ -29,6 +29,13 @@ import {
   shutdown,
 } from '@/lib/db-unified';
 
+// Pull the real (un-mocked) helper. The default `jest.mock('@/lib/db-unified', ...)`
+// in setup/prisma.ts replaces the module with stubs; we want to test the actual
+// matcher logic, not the stub. requireActual reaches the real export.
+const { isPoolFullError } = jest.requireActual('@/lib/db-unified') as {
+  isPoolFullError: (error: Error) => boolean;
+};
+
 describe('db-unified.ts - Database Connection Resilience', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -505,6 +512,51 @@ describe('db-unified.ts - Socket Timeout Detection', () => {
  * Tests for Quick Health Check Function
  * Tests the expected behavior and response structure of quickHealthCheck
  */
+describe('db-unified.ts - Pool-Full Error Detection', () => {
+  describe('isPoolFullError() recognizes pool exhaustion', () => {
+    it('recognizes Prisma error code P2024', () => {
+      const error = new Error('some unrelated message') as Error & { code?: string };
+      error.code = 'P2024';
+      expect(isPoolFullError(error)).toBe(true);
+    });
+
+    it('recognizes the "Timed out fetching a new connection" message', () => {
+      const error = new Error(
+        'Timed out fetching a new connection from the connection pool. (timeout: 15, limit: 10)'
+      );
+      expect(isPoolFullError(error)).toBe(true);
+    });
+
+    it('recognizes the "Connection pool timeout" message', () => {
+      const error = new Error('Connection pool timeout while acquiring connection');
+      expect(isPoolFullError(error)).toBe(true);
+    });
+  });
+
+  describe('isPoolFullError() rejects non-pool errors', () => {
+    it('returns false for ECONNRESET', () => {
+      const error = new Error('ECONNRESET: socket hang up');
+      expect(isPoolFullError(error)).toBe(false);
+    });
+
+    it('returns false for engine-not-connected errors (P1001 / engine init)', () => {
+      const error = new Error('Engine is not yet connected') as Error & { code?: string };
+      error.code = 'P1001';
+      expect(isPoolFullError(error)).toBe(false);
+    });
+
+    it('returns false for plain socket timeout (different recovery path)', () => {
+      const error = new Error('Socket timeout: the database failed to respond to a query');
+      expect(isPoolFullError(error)).toBe(false);
+    });
+
+    it('returns false for authentication errors', () => {
+      const error = new Error('FATAL: password authentication failed for user "postgres"');
+      expect(isPoolFullError(error)).toBe(false);
+    });
+  });
+});
+
 describe('db-unified.ts - Quick Health Check', () => {
   describe('quickHealthCheck() expected behavior', () => {
     // Create a mock that matches the expected behavior

--- a/src/lib/db-unified.ts
+++ b/src/lib/db-unified.ts
@@ -95,7 +95,8 @@ function buildOptimizedPoolerUrl(baseUrl: string): string {
 
       // Optimized timeouts for webhook processing and Vercel cold starts
       if (isProduction) {
-        url.searchParams.set('pool_timeout', '300'); // 5 minutes for high load
+        // Fast-fail on pool exhaustion so withRetry can recover instead of stalling 5 min.
+        url.searchParams.set('pool_timeout', '15');
         url.searchParams.set('connection_timeout', String(CONNECTION_TIMEOUT_SECONDS)); // Configurable for cold starts
         url.searchParams.set('statement_timeout', '60000'); // 60 seconds for queries
         url.searchParams.set('idle_in_transaction_session_timeout', '60000');
@@ -103,23 +104,25 @@ function buildOptimizedPoolerUrl(baseUrl: string): string {
 
         if (process.env.DB_DEBUG === 'true') {
           console.log(
-            '🚀 Production Supabase pooler: 300s pool timeout, 60s statement timeout, 120s socket timeout'
+            '🚀 Production Supabase pooler: 15s pool timeout, 60s statement timeout, 120s socket timeout'
           );
         }
       } else {
-        url.searchParams.set('pool_timeout', '120');
+        url.searchParams.set('pool_timeout', '15');
         url.searchParams.set('connection_timeout', '15');
         url.searchParams.set('statement_timeout', '60000');
         url.searchParams.set('idle_in_transaction_session_timeout', '60000');
         url.searchParams.set('socket_timeout', '60');
 
         if (process.env.DB_DEBUG === 'true') {
-          console.log('🔧 Development Supabase pooler: 120s pool timeout, 60s statement timeout');
+          console.log('🔧 Development Supabase pooler: 15s pool timeout, 60s statement timeout');
         }
       }
 
-      // Limit connections per serverless instance to avoid exhausting the Supabase pool
-      url.searchParams.set('connection_limit', '5');
+      // Per-instance connection cap. Raised from 5 to 10: 5 was too tight for an
+      // RSC tree that fans out under Suspense plus concurrent requests on the
+      // same lambda. Stays well under Supabase's per-pooler ceiling.
+      url.searchParams.set('connection_limit', '10');
     } else {
       // Non-Supabase database configuration
       if (isProduction) {
@@ -628,19 +631,21 @@ export async function ensureConnection(maxRetries: number = 3): Promise<void> {
       const isRetryableError = isConnectionError(error as Error);
 
       if (isRetryableError && attempt < maxRetries) {
+        const poolFull = isPoolFullError(error as Error);
         console.warn(`Connection attempt ${attempt}/${maxRetries} failed, retrying...`);
 
         try {
-          // Force client reinitialization on connection errors
-          if (prismaClient) {
-            await prismaClient.$disconnect();
+          // Pool-full retries reuse the existing client; only engine-level
+          // failures justify tearing it down.
+          if (!poolFull) {
+            if (prismaClient) {
+              await prismaClient.$disconnect();
+            }
+            prismaClient = null;
+            globalForPrisma.prisma = undefined;
+            initPromise = null;
           }
           await new Promise(resolve => setTimeout(resolve, 1000 * attempt));
-
-          // Reset client to force reinitialization
-          prismaClient = null;
-          globalForPrisma.prisma = undefined;
-          initPromise = null;
         } catch (reconnectError) {
           console.warn(
             `Reconnection attempt ${attempt} failed:`,
@@ -764,6 +769,22 @@ function isSocketTimeoutError(error: Error): boolean {
 }
 
 /**
+ * Pool-full errors are retryable, but the underlying client is healthy.
+ * Tearing it down on every retry kicks other in-flight queries off the pool
+ * and creates a reconnection storm — exactly the wrong response.
+ *
+ * Exported for testing.
+ */
+export function isPoolFullError(error: Error): boolean {
+  if ((error as any).code === 'P2024') return true;
+  const msg = error.message;
+  return (
+    msg.includes('Timed out fetching a new connection') ||
+    msg.includes('Connection pool timeout')
+  );
+}
+
+/**
  * Check if error is connection-related (including transient pooler errors)
  */
 function isConnectionError(error: Error): boolean {
@@ -856,27 +877,33 @@ export async function withRetry<T>(
       consecutiveFailures++;
 
       if (isConnectionError(lastError) && attempt < maxRetries) {
+        const poolFull = isPoolFullError(lastError);
+
         // Log connection errors with structured data
         console.warn('[DB_OPERATION_RETRY]', {
           operation: operationName,
           attempt,
           maxRetries,
           consecutiveFailures,
+          poolFull,
           error: lastError.message.substring(0, 100),
           errorCode: (lastError as any).code,
         });
 
-        // For connection errors, force client reinitialization
-        try {
-          if (prismaClient) {
-            await prismaClient.$disconnect();
-          }
-          prismaClient = null;
-          globalForPrisma.prisma = undefined;
-          initPromise = null;
-        } catch (cleanupError) {
-          if (process.env.DB_DEBUG === 'true') {
-            console.warn('Error during client cleanup:', cleanupError);
+        // Pool-full means the client is healthy — just back off and retry.
+        // Other connection errors (engine dead, ECONNRESET, etc.) need a fresh client.
+        if (!poolFull) {
+          try {
+            if (prismaClient) {
+              await prismaClient.$disconnect();
+            }
+            prismaClient = null;
+            globalForPrisma.prisma = undefined;
+            initPromise = null;
+          } catch (cleanupError) {
+            if (process.env.DB_DEBUG === 'true') {
+              console.warn('Error during client cleanup:', cleanupError);
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

Fixes Prisma **P2024 connection pool starvation** on the static homepage (`src/app/(static)/page.tsx`). Two surgical changes in `src/lib/db-unified.ts`:

**Pool config** (`buildOptimizedPoolerUrl`):
- Production: `pool_timeout` 300s → 15s, `connection_limit` 5 → 10.
- Dev: `pool_timeout` 120s → 15s.

**Retry behavior** (`withRetry`, `ensureConnection`):
- New `isPoolFullError()` helper recognizes P2024 / "Timed out fetching a new connection" / "Connection pool timeout".
- On a pool-full error, the retry path no longer calls `prismaClient.$disconnect()` + nulls the singleton + clears the global. The pool was busy, not the client.
- Engine errors (ECONNRESET, P1001, "Engine is not yet connected") still regenerate the client as before.

The original failure mode: 5 concurrent connections, an RSC tree fanning out under `<Suspense>`, plus concurrent requests on the same Vercel lambda. Pool fills, callers wait 5 minutes, the proxy's retry kicks healthy clients off the pool to create new ones, snowballs.

## Test Coverage

Added 7 unit tests for `isPoolFullError` covering P2024 code, both message matchers, and negative cases (ECONNRESET, P1001, plain socket timeout, auth errors). The 4 conditional branches in `withRetry`/`ensureConnection` aren't directly exercised — the project's test setup mocks both functions for unrelated tests, and routing real errors through them would require invasive setup changes. Branches are gated entirely on `isPoolFullError`'s output, which **is** verified.

```
src/lib/db-unified.ts (changes vs development)
  isPoolFullError matchers: 7/7 paths tested ★★★
  withRetry pool-full branch: gated by helper (verified) — no direct test
  ensureConnection pool-full branch: gated by helper (verified) — no direct test
```

Tests: 68 → 75 (+7 new). Full critical suite: 632/632 pass.

## Pre-Landing Review

No issues found. Diff is 129 lines in one file plus tests. Surgical, well-bounded.

## Adversarial Review (informational)

Claude adversarial subagent surfaced 10 findings; user reviewed and chose to ship as-is with accurate documentation. Notable:

- **Worst-case retry latency is ~48s, not ~7s.** With `pool_timeout=15s × maxRetries=3` plus exponential backoff (1s + 2s capped), the upper bound is `15+1+15+2+15 ≈ 48s` before P2024 surfaces to the caller. In normal brief contention the retry path returns in <2s. 48s only happens under **sustained** pool starvation — at which point P2024 surfacing is the correct behavior, not a bug.
- **Cross-request race on the singleton.** A concurrent request hitting an engine error (ECONNRESET) can null the client mid-flight while a pool-full retry is reusing it. The pool-full retry then gets a fresh client via `getPrismaClient()` — defeats the "reuse healthy client" intent in that interleaving. Real but rare; full mitigation needs a generation counter / mutex, which exceeds the approved scope (config + retry fix only).
- **`connection_limit=10` per lambda × N lambdas vs Supabase pooler ceiling.** Supabase pgbouncer transaction-mode default is ~200 client connections (free tier) / ~400 (pro). With 10/instance, ~20–40 concurrent lambdas exhausts the pool. **Action item before/after deploy: confirm Supabase plan + pooler `default_pool_size`/`max_client_conn` and watch the dashboard.**
- **`consecutiveFailures` still increments on pool-full retries.** Could indirectly trip the circuit breaker on sustained storms. Effect is bounded since we no longer call `createPrismaClient` for pool-full errors. Worth monitoring.
- **Dev `connection_limit=10`** applies via the shared `connection_limit` line. Local Postgres without pgbouncer doesn't care; flagged for awareness.

Findings 7-10 (test fragility, missing pool-full metric, etc.) deferred to follow-up.

## Plan Completion

Plan: `~/.claude/plans/can-we-run-parallels-spicy-koala.md`. All implementation items DONE (5/5). Test items: added 7 unit tests for the helper.

## Verification

Manual smoke (run after deploy to development):

```bash
# Local: spin up dev server and hit `/` under concurrency
for i in {1..30}; do (curl -s -o /dev/null http://localhost:3000/ &); done; wait
# Expect: zero P2024 errors. Brief contention should recover via withRetry within seconds.
```

Production:
- Watch Vercel logs for `[DB_OPERATION_RETRY]` entries with `poolFull: true` — that's the new canary.
- Watch Supabase Dashboard → Database → Pooler "active connections" — should sit single digits per instance with brief spikes.
- If P2024 returns, escalate to `connection_limit=15` and audit admin-products / catering paths for query fan-out.

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm lint` — 0 errors (1 pre-existing `console.log` warning unchanged)
- [x] `pnpm jest src/__tests__/lib/db-unified.test.ts` — 75/75 pass (was 68)
- [x] `pnpm test:critical` — 632/632 pass
- [ ] Production canary: monitor Supabase pooler + Vercel logs for 30 min after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)