### PR TITLE
ci: bump pnpm/action-setup to v6 and drop version override (supersedes #177)

### DIFF
--- a/.github/workflows/a11y-tests.yml
+++ b/.github/workflows/a11y-tests.yml
@@ -20,7 +20,6 @@ on:
 
 env:
   NODE_OPTIONS: '--max-old-space-size=4096'
-  PNPM_VERSION: '10.11.1'
 
 jobs:
   a11y-tests:
@@ -36,9 +35,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -14,7 +14,6 @@ permissions:
 
 env:
   NODE_VERSION: '20.x'
-  PNPM_VERSION: '10.11.1'
 
 jobs:
   # Desktop Lighthouse Tests
@@ -31,9 +30,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -127,9 +124,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/pre-deployment.yml
+++ b/.github/workflows/pre-deployment.yml
@@ -16,7 +16,6 @@ on:
 
 env:
   NODE_VERSION: '20.x'
-  PNPM_VERSION: '10.11.1'
 
 # Grant permissions for the workflow to comment on PRs
 permissions:
@@ -60,9 +59,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Cache dependencies
         uses: actions/cache@v5
@@ -293,9 +290,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -13,7 +13,6 @@ permissions:
 
 env:
   NODE_VERSION: '20.x'
-  PNPM_VERSION: '10.11.1'
 
 jobs:
   # Job 1: Setup and cache dependencies
@@ -32,9 +31,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Generate cache key
         id: cache-key
@@ -65,9 +62,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Restore dependencies
         uses: actions/cache@v5
@@ -99,9 +94,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Restore dependencies
         uses: actions/cache@v5
@@ -176,9 +169,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Restore dependencies
         uses: actions/cache@v5
@@ -233,9 +224,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Restore dependencies
         uses: actions/cache@v5
@@ -454,9 +443,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Restore dependencies
         uses: actions/cache@v5

--- a/.github/workflows/weekly-backup.yml
+++ b/.github/workflows/weekly-backup.yml
@@ -11,7 +11,6 @@ permissions:
 
 env:
   NODE_VERSION: '20.x'
-  PNPM_VERSION: '10.11.1'
   BUCKET: db-backups
   RETENTION_WEEKS: '8'
 
@@ -38,9 +37,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/weekly-security-audit.yml
+++ b/.github/workflows/weekly-security-audit.yml
@@ -12,7 +12,6 @@ permissions:
 
 env:
   NODE_VERSION: '20.x'
-  PNPM_VERSION: '10.17.1'
 
 jobs:
   audit:
@@ -29,9 +28,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies (audit needs the full lockfile graph)
         run: pnpm install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
## Summary

Dependabot's PR #177 (bumps `pnpm/action-setup` v2 → v6) fails CI because v6 enforces a single source of truth for the pnpm version. Our workflows pin both, which conflicts:

```
Error: Multiple versions of pnpm specified:
  - version 10.11.1 in the GitHub Action config with the key "version"
  - version pnpm@10.17.1+sha512... in the package.json with the key "packageManager"
Remove one of these versions to avoid ERR_PNPM_BAD_PM_VERSION
```

This PR removes the `with: version:` block and the unused `PNPM_VERSION` env from all 13 call sites across 6 workflows, then bumps `pnpm/action-setup@v2 → @v6` in the same change. `package.json` (`packageManager: pnpm@10.17.1`) is the single source of truth going forward.

Side benefit: workflows were silently drifting (pinned to `10.11.1` while `packageManager` is on `10.17.1`). That drift is now gone.

## Files changed

- `.github/workflows/test-suite.yml` (6 call sites)
- `.github/workflows/pre-deployment.yml` (2 call sites)
- `.github/workflows/lighthouse.yml` (2 call sites)
- `.github/workflows/a11y-tests.yml` (1 call site)
- `.github/workflows/weekly-backup.yml` (1 call site)
- `.github/workflows/weekly-security-audit.yml` (1 call site)

## Test plan

- [x] Local YAML parse: all 6 workflows load cleanly
- [x] `grep -r "pnpm/action-setup" .github/workflows/` confirms all 13 sites on `@v6`
- [x] `grep -r "PNPM_VERSION" .github/workflows/` returns zero matches
- [ ] CI: every workflow's `Setup pnpm` step succeeds and installs pnpm `10.17.1` (the `packageManager` version)
- [ ] Close #177 as superseded once this lands

## Follow-up

After this merges, #177 can be closed (it would conflict on the same files anyway). If you'd rather keep #177 alive, rebase it on top of this — Dependabot will then have nothing to do because the `@v2 → @v6` bump is already applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)