### PR TITLE
chore(test): auto-collect coverage in CI

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -247,7 +247,7 @@ const config: Config = {
       statements: 80,
     },
   },
-  collectCoverage: false, // Enable only when running coverage explicitly
+  collectCoverage: process.env.CI === 'true', // Auto-collect in CI; opt-in locally via `pnpm test:coverage`
   passWithNoTests: false,
   verbose: true,
   maxWorkers: 1, // Run tests serially to avoid DB conflicts


### PR DESCRIPTION
## Summary

Flips `jest.config.ts:250` from `collectCoverage: false` to `collectCoverage: process.env.CI === 'true'` so coverage thresholds are evaluated automatically on every CI run.

This is Step 1 of Sprint 4.2 in `docs/ROADMAP_2026_Q2_DEFERRED.md` ("Coverage Enforcement in CI") and Quick Win #1 in the Apr 26 client roadmap.

## What this changes

- ✅ Coverage gets collected on PRs + pushes to `main`/`development`
- ✅ Thresholds (50/55/60/60 global; 75-80% on critical paths) are evaluated by Jest
- ✅ Local runs stay fast — opt-in via `pnpm test:coverage` (unchanged)

## What this does NOT change yet

`.github/workflows/test-suite.yml` keeps `continue-on-error: true` on the coverage step (line 327). Per the roadmap: *"Start with `continue-on-error: true` for 2 weeks to baseline, then make blocking."* Hardening to a blocking gate is a follow-up after the 44 skipped Jest suites are addressed (Sprint 3.3 + 4.1).

## Test plan

- [ ] CI `Generate coverage report` step emits a real `coverage-summary.json` artifact
- [ ] `Run test health check` prints actual coverage percentages
- [ ] Local `pnpm test:unit` (no CI env var) does NOT collect coverage — runs at usual speed

🤖 Generated with [Claude Code](https://claude.com/claude-code)