### PR TITLE
feat(db): route Prisma slow queries (>500ms) to Sentry

### DIFF
--- a/src/lib/db-unified.ts
+++ b/src/lib/db-unified.ts
@@ -1,6 +1,12 @@
 import { PrismaClient, Prisma } from '@prisma/client';
+import * as Sentry from '@sentry/nextjs';
 import { dbCircuitBreaker, getCircuitBreakerStatus } from './db-circuit-breaker';
 import { dbPoolMetrics } from './db-pool-metrics';
+import { performanceMonitor } from './monitoring/performance';
+
+// Sprint 5.1: queries slower than this are reported to Sentry as warnings.
+// Local in-memory tracking via performanceMonitor uses its own (lower) threshold.
+const SLOW_QUERY_THRESHOLD_MS = 500;
 
 /**
  * Unified database client that consolidates all database connection logic
@@ -177,12 +183,11 @@ async function createPrismaClient(retryAttempt: number = 0): Promise<PrismaClien
   const databaseUrl = getBestDatabaseUrl();
 
   const client = new PrismaClient({
-    log: isProduction
-      ? ['error']
-      : [
-          { emit: 'event', level: 'error' },
-          { emit: 'event', level: 'warn' },
-        ],
+    log: [
+      { emit: 'event', level: 'query' },
+      { emit: 'event', level: 'error' },
+      { emit: 'event', level: 'warn' },
+    ],
     errorFormat: 'minimal',
     datasources: {
       db: { url: databaseUrl },
@@ -199,6 +204,33 @@ async function createPrismaClient(retryAttempt: number = 0): Promise<PrismaClien
       });
     });
   }
+
+  // Sprint 5.1: route slow queries to Sentry. Bypasses the production
+  // breadcrumb filter (sentry.server.config.ts) by using captureMessage —
+  // slow queries are exceptional events, not routine breadcrumbs.
+  client.$on('query' as never, (event: Prisma.QueryEvent) => {
+    void performanceMonitor
+      .trackDatabaseQuery(event.query, event.duration, event.params ? [event.params] : undefined)
+      .catch(() => {
+        /* tracking is best-effort; never block a query path */
+      });
+
+    if (event.duration < SLOW_QUERY_THRESHOLD_MS) return;
+
+    Sentry.captureMessage('Slow database query', {
+      level: 'warning',
+      tags: {
+        slow_query: 'true',
+        duration_ms: String(event.duration),
+      },
+      extra: {
+        query: event.query,
+        params: event.params,
+        target: event.target,
+        timestamp: event.timestamp?.toISOString?.() ?? new Date().toISOString(),
+      },
+    });
+  });
 
   // CRITICAL: Explicitly connect the client to start the engine with enhanced timeout handling
   try {


### PR DESCRIPTION
## Summary

Adds a Prisma `query`-event handler in `src/lib/db-unified.ts` that:

1. Updates the in-process `performanceMonitor` on every query (already exposes `getSlowQueries()` for `/admin` dashboards).
2. Calls `Sentry.captureMessage('Slow database query', ...)` for queries slower than **500ms**, tagged `slow_query:true` + `duration_ms:<n>`, with full query + params + target in `extra`.

Implements Sprint 5.1 in `docs/ROADMAP_2026_Q2_DEFERRED.md` and quick win #3 from the Apr 26 client roadmap.

## Why `captureMessage`, not breadcrumbs

`sentry.server.config.ts:118-132` strips `category === 'query'` breadcrumbs in production (correctly — every query as a breadcrumb is noise). Slow queries are exceptional events; they belong as their own Sentry issues, groupable and searchable by tag.

## Test plan

- [ ] `pnpm type-check` passes
- [ ] In staging, hit an endpoint that runs `SELECT pg_sleep(0.6)` — verify a "Slow database query" warning appears in Sentry within 30s, tagged `slow_query:true`
- [ ] Confirm normal (fast) queries do **not** produce Sentry events
- [ ] Existing `/admin` performance dashboard still surfaces slow queries via `performanceMonitor.getSlowQueries()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)