### PR TITLE
feat(deploy): Docker image build for Dokploy self-hosting (Vercel → VPS migration, phase 1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Keep the build context small + avoid leaking local state into the image.
+
+# Dependencies & build output (rebuilt inside the image)
+node_modules
+.next
+out
+build
+dist
+.pnpm-store
+
+# Local env / secrets — set these as Build Args (CI) / runtime env (Dokploy)
+.env
+.env.*
+!.env.example
+
+# VCS & CI
+.git
+.gitignore
+.github
+.vercel
+.vercelignore
+.infisical.json
+
+# Tests, coverage, e2e artifacts (not needed at runtime)
+coverage
+playwright-report
+test-results
+tests
+e2e
+.auth
+
+# Editor / OS cruft
+.vscode
+.idea
+.DS_Store
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Docker meta
+Dockerfile
+.dockerignore
+
+# Misc local-only
+.husky
+*.local
+docs
+scripts/backups

--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,10 @@ SQUARE_ACCESS_TOKEN="your-access-token"
 SQUARE_PRODUCTION_TOKEN="your-production-token"
 SQUARE_SANDBOX_APPLICATION_ID="your-sandbox-app-id"
 SQUARE_SANDBOX_TOKEN="your-sandbox-token"
-SQUARE_WEBHOOK_SIGNATURE_KEY="your-webhook-signature-key"
+# NOTE: the app reads SQUARE_WEBHOOK_SECRET (see src/lib/env/env.ts), not the
+# old SQUARE_WEBHOOK_SIGNATURE_KEY name.
+SQUARE_WEBHOOK_SECRET="your-webhook-signature-key"
+SQUARE_WEBHOOK_SECRET_SANDBOX="your-sandbox-webhook-signature-key"
 SQUARE_CATALOG_USE_PRODUCTION="false"
 SQUARE_TRANSACTIONS_USE_SANDBOX="true"
 USE_SQUARE_SANDBOX="true"
@@ -71,6 +74,10 @@ TURBO_RUN_SUMMARY="true"
 
 # Rate Limiting
 BYPASS_RATE_LIMIT="false"
+
+# Cron authentication — /api/cron/* routes require `Authorization: Bearer $CRON_SECRET`.
+# WARNING: if unset, process-webhooks-fixed and square-write-queue skip auth entirely.
+CRON_SECRET="generate-a-long-random-string"
 
 # Development flags
 NX_DAEMON="false"

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,190 @@
+name: Build & Push Image
+
+# Builds the production Docker image in CI (off the VPS) and pushes it to GHCR.
+# The self-host box (Dokploy on the arm64 Hetzner host) pulls and runs the
+# prebuilt image — no `next build` ever runs on the server. This replaces
+# Vercel's build + hosting for destino-sf.
+#
+# Multi-arch WITHOUT QEMU: amd64 builds on the standard runner, arm64 builds
+# natively on GitHub's ubuntu-24.04-arm runner (free for public repos), then a
+# merge job assembles the multi-arch manifest. This avoids the ~1-2 h QEMU
+# penalty the ready-set workflow pays.
+#
+# Required repo config (Settings -> Secrets and variables -> Actions):
+#   Variables (non-secret, baked into the client bundle at build time):
+#     NEXT_PUBLIC_SUPABASE_URL
+#     NEXT_PUBLIC_APP_URL
+#     NEXT_PUBLIC_SITE_URL
+#     NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+#     NEXT_PUBLIC_SENTRY_ENVIRONMENT
+#     NEXT_PUBLIC_STORE_ADDRESS          (optional)
+#     NEXT_PUBLIC_STORE_HOURS            (optional)
+#     NEXT_PUBLIC_UMAMI_SRC              (optional)
+#     NEXT_PUBLIC_UMAMI_WEBSITE_ID       (optional)
+#     NEXT_PUBLIC_SANITY_PROJECT_ID      (optional)
+#     NEXT_PUBLIC_SANITY_DATASET         (optional)
+#   Secrets:
+#     NEXT_PUBLIC_SUPABASE_ANON_KEY      (public anon key, but kept as secret)
+#     NEXT_PUBLIC_SENTRY_DSN
+#     NEXT_PUBLIC_MIXPANEL_TOKEN         (optional)
+#     NEXT_PUBLIC_ADMIN_API_KEY          (optional)
+#     BUILD_DATABASE_URL                 (optional: only if pages hit the DB at build)
+#     BUILD_DIRECT_URL                   (optional)
+#     SENTRY_AUTH_TOKEN                  (optional: source-map upload)
+#     DOKPLOY_DEV_DEPLOY_WEBHOOK         (optional: auto-redeploy dev mirror)
+#     DOKPLOY_PROD_DEPLOY_WEBHOOK        (optional: auto-redeploy prod app)
+#
+# Runtime server secrets (real DATABASE_URL, Supabase service key, Square,
+# Resend, Shippo, Upstash, CRON_SECRET, etc.) are set in DOKPLOY's env, NOT
+# here — they are not needed to build the image (the Dockerfile uses
+# placeholders to satisfy the Zod env schema during `next build`).
+
+on:
+  push:
+    branches: [main, development]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }} # ReadySet1/destino-sf -> ghcr.io/readyset1/destino-sf
+
+jobs:
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Prepare platform slug
+        run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> $GITHUB_ENV
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+          build-args: |
+            NEXT_PUBLIC_SUPABASE_URL=${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
+            NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+            NEXT_PUBLIC_APP_URL=${{ vars.NEXT_PUBLIC_APP_URL }}
+            NEXT_PUBLIC_SITE_URL=${{ vars.NEXT_PUBLIC_SITE_URL }}
+            NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${{ vars.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
+            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+            NEXT_PUBLIC_SENTRY_ENVIRONMENT=${{ vars.NEXT_PUBLIC_SENTRY_ENVIRONMENT }}
+            NEXT_PUBLIC_MIXPANEL_TOKEN=${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }}
+            NEXT_PUBLIC_ADMIN_API_KEY=${{ secrets.NEXT_PUBLIC_ADMIN_API_KEY }}
+            NEXT_PUBLIC_UMAMI_SRC=${{ vars.NEXT_PUBLIC_UMAMI_SRC }}
+            NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ vars.NEXT_PUBLIC_UMAMI_WEBSITE_ID }}
+            NEXT_PUBLIC_STORE_ADDRESS=${{ vars.NEXT_PUBLIC_STORE_ADDRESS }}
+            NEXT_PUBLIC_STORE_HOURS=${{ vars.NEXT_PUBLIC_STORE_HOURS }}
+            NEXT_PUBLIC_SANITY_PROJECT_ID=${{ vars.NEXT_PUBLIC_SANITY_PROJECT_ID }}
+            NEXT_PUBLIC_SANITY_DATASET=${{ vars.NEXT_PUBLIC_SANITY_DATASET }}
+            DATABASE_URL=${{ secrets.BUILD_DATABASE_URL }}
+            DIRECT_URL=${{ secrets.BUILD_DIRECT_URL }}
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge multi-arch manifest
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+      # Close the push -> live loop: tell Dokploy to pull + redeploy.
+      # development -> dev mirror, main -> prod app. Self-skips if unset.
+      - name: Trigger Dokploy redeploy
+        env:
+          PROD_WEBHOOK: ${{ secrets.DOKPLOY_PROD_DEPLOY_WEBHOOK }}
+          DEV_WEBHOOK: ${{ secrets.DOKPLOY_DEV_DEPLOY_WEBHOOK }}
+        run: |
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            WEBHOOK="$PROD_WEBHOOK"
+          else
+            WEBHOOK="$DEV_WEBHOOK"
+          fi
+          if [ -z "$WEBHOOK" ]; then
+            echo "Dokploy deploy webhook not set for this branch — skipping auto-redeploy."
+            exit 0
+          fi
+          curl --fail --silent --show-error -X GET "$WEBHOOK"
+          echo "Dokploy redeploy triggered."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,174 @@
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage production image for the Destino SF Next.js app.
+# - Uses Next.js standalone output (next.config.js -> output: 'standalone').
+# - Debian "bookworm-slim" (glibc) base so Prisma's `native` engine target
+#   works on both amd64 and arm64 (the Dokploy Hetzner ARM box) without
+#   touching schema.prisma binaryTargets.
+# - pnpm pinned via corepack to match package.json "packageManager".
+#
+# Built in GitHub Actions (see .github/workflows/build-and-push.yml) and run
+# as a prebuilt image by Dokploy — `next build` never runs on the VPS.
+
+ARG NODE_IMAGE=node:20-bookworm-slim
+
+# ---------- deps: install node_modules only (cached layer) ----------
+FROM ${NODE_IMAGE} AS deps
+WORKDIR /app
+
+# Prisma needs openssl at install/generate time.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable
+
+# package.json has `postinstall: prisma generate`, so the schema must be
+# present before `pnpm install` or the install itself fails.
+COPY package.json pnpm-lock.yaml .npmrc .pnpmrc ./
+COPY prisma ./prisma
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile
+
+# ---------- builder: prisma generate + next build ----------
+FROM ${NODE_IMAGE} AS builder
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# --- Build-time public env (Next.js inlines NEXT_PUBLIC_* at build) ---
+# These MUST be real values at build time or the client bundle ships blanks.
+# Wired from GitHub Actions Variables/Secrets in build-and-push.yml.
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ARG NEXT_PUBLIC_APP_URL
+ARG NEXT_PUBLIC_SITE_URL
+ARG NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+ARG NEXT_PUBLIC_SENTRY_DSN
+ARG NEXT_PUBLIC_SENTRY_ENVIRONMENT
+ARG NEXT_PUBLIC_APP_VERSION
+ARG NEXT_PUBLIC_ADMIN_API_KEY
+ARG NEXT_PUBLIC_MIXPANEL_TOKEN
+ARG NEXT_PUBLIC_UMAMI_SRC
+ARG NEXT_PUBLIC_UMAMI_WEBSITE_ID
+ARG NEXT_PUBLIC_STORE_ADDRESS
+ARG NEXT_PUBLIC_STORE_HOURS
+ARG NEXT_PUBLIC_SANITY_PROJECT_ID
+ARG NEXT_PUBLIC_SANITY_DATASET
+
+# --- Build-time server env ---
+# src/lib/env/env.ts runs `envSchema.parse(process.env)` at module scope, so
+# `next build` needs every required var to exist. Server-only values are
+# placeholders (same approach as pre-deployment.yml CI builds) — the real
+# values come from Dokploy's runtime env, which this builder stage never
+# reaches. DATABASE_URL/DIRECT_URL may be real (BUILD_* secrets) if static
+# generation needs DB reads.
+ARG DATABASE_URL
+ARG DIRECT_URL
+ARG SENTRY_AUTH_TOKEN
+
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY \
+    NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL \
+    NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL \
+    NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=$NEXT_PUBLIC_GOOGLE_MAPS_API_KEY \
+    NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN \
+    NEXT_PUBLIC_SENTRY_ENVIRONMENT=$NEXT_PUBLIC_SENTRY_ENVIRONMENT \
+    NEXT_PUBLIC_APP_VERSION=$NEXT_PUBLIC_APP_VERSION \
+    NEXT_PUBLIC_ADMIN_API_KEY=$NEXT_PUBLIC_ADMIN_API_KEY \
+    NEXT_PUBLIC_MIXPANEL_TOKEN=$NEXT_PUBLIC_MIXPANEL_TOKEN \
+    NEXT_PUBLIC_UMAMI_SRC=$NEXT_PUBLIC_UMAMI_SRC \
+    NEXT_PUBLIC_UMAMI_WEBSITE_ID=$NEXT_PUBLIC_UMAMI_WEBSITE_ID \
+    NEXT_PUBLIC_STORE_ADDRESS=$NEXT_PUBLIC_STORE_ADDRESS \
+    NEXT_PUBLIC_STORE_HOURS=$NEXT_PUBLIC_STORE_HOURS \
+    NEXT_PUBLIC_SANITY_PROJECT_ID=$NEXT_PUBLIC_SANITY_PROJECT_ID \
+    NEXT_PUBLIC_SANITY_DATASET=$NEXT_PUBLIC_SANITY_DATASET \
+    DATABASE_URL=${DATABASE_URL:-postgresql://build:build@localhost:5432/build} \
+    DIRECT_URL=${DIRECT_URL:-postgresql://build:build@localhost:5432/build} \
+    SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN \
+    SUPABASE_SERVICE_ROLE_KEY=build-placeholder \
+    ADMIN_EMAIL=build@placeholder.local \
+    FROM_EMAIL=build@placeholder.local \
+    RESEND_API_KEY=build-placeholder \
+    SQUARE_ENVIRONMENT=sandbox \
+    SQUARE_LOCATION_ID=build-placeholder \
+    SQUARE_ACCESS_TOKEN=build-placeholder \
+    SQUARE_WEBHOOK_SECRET=build-placeholder \
+    SHIPPING_ORIGIN_CITY="San Francisco" \
+    SHIPPING_ORIGIN_EMAIL=build@placeholder.local \
+    SHIPPING_ORIGIN_NAME=build-placeholder \
+    SHIPPING_ORIGIN_PHONE=4155550000 \
+    SHIPPING_ORIGIN_STATE=CA \
+    SHIPPING_ORIGIN_STREET1=build-placeholder \
+    SHIPPING_ORIGIN_ZIP=94102 \
+    SHIPPO_API_KEY=build-placeholder \
+    SHOP_NAME="Destino SF" \
+    UPSTASH_REDIS_REST_TOKEN=build-placeholder \
+    UPSTASH_REDIS_REST_URL=https://build-placeholder.upstash.io \
+    HUSKY=0 \
+    NEXT_TELEMETRY_DISABLED=1 \
+    CI=true
+
+# The build needs more heap than Node's ~2 GB default (OOMs otherwise).
+# GitHub-hosted public-repo runners (amd64 and arm64) have 16 GB RAM.
+ENV NODE_OPTIONS=--max-old-space-size=6144
+
+# Unset OPTIONAL vars that arrived as empty strings (unset build-args come
+# through as "" and src/env.ts (t3-env, no emptyStringAsUndefined) rejects
+# empty strings for .url().optional() fields). Required vars stay put so a
+# missing value still fails the build loudly.
+# `prebuild` runs `prisma generate`; then `next build` emits .next/standalone.
+RUN set -e; \
+    for v in NEXT_PUBLIC_SENTRY_DSN NEXT_PUBLIC_SENTRY_ENVIRONMENT \
+             NEXT_PUBLIC_APP_VERSION NEXT_PUBLIC_ADMIN_API_KEY \
+             NEXT_PUBLIC_MIXPANEL_TOKEN NEXT_PUBLIC_UMAMI_SRC \
+             NEXT_PUBLIC_UMAMI_WEBSITE_ID NEXT_PUBLIC_STORE_ADDRESS \
+             NEXT_PUBLIC_STORE_HOURS NEXT_PUBLIC_SANITY_PROJECT_ID \
+             NEXT_PUBLIC_SANITY_DATASET SENTRY_AUTH_TOKEN; do \
+      eval "val=\${$v:-}"; \
+      if [ -z "$val" ]; then unset "$v"; fi; \
+    done; \
+    pnpm build
+
+# ---------- runner: minimal standalone server ----------
+FROM ${NODE_IMAGE} AS runner
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+# Run as non-root.
+RUN groupadd --system --gid 1001 nodejs \
+  && useradd --system --uid 1001 --gid nodejs nextjs
+
+# Standalone output bundles a minimal node_modules + server.js.
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+EXPOSE 3000
+
+# NOTE: deliberately NO strict HEALTHCHECK here. /api/health can 503 at
+# baseline (degraded DB latency), and a 2xx-only HEALTHCHECK makes Swarm
+# crash-loop the service (ready-set gotcha). Liveness is handled by the
+# Dokploy healthCheckSwarm override (accepts any HTTP response).
+
+CMD ["node", "server.js"]

--- a/src/lib/env/env.ts
+++ b/src/lib/env/env.ts
@@ -56,6 +56,11 @@ const envSchema = z.object({
   UPSTASH_REDIS_REST_TOKEN: z.string().min(1, 'UPSTASH_REDIS_REST_TOKEN is required'),
   UPSTASH_REDIS_REST_URL: z.string().url('UPSTASH_REDIS_REST_URL must be a valid URL'),
 
+  // Cron authentication (Bearer token for /api/cron/* routes). Optional so
+  // local dev keeps working, but several cron routes skip auth when unset —
+  // always set it in deployed environments.
+  CRON_SECRET: z.string().optional(),
+
   // Optional configuration
   BYPASS_RATE_LIMIT: z.string().optional().default('false'),
   NX_DAEMON: z.string().optional().default('false'),


### PR DESCRIPTION
## Summary

Phase 1 of the destino-sf Vercel → Dokploy/VPS migration, porting the proven ready-set pattern (build in CI → push to GHCR → Dokploy runs the prebuilt image; no `next build` on the server). Database stays on Supabase — compute-layer move only.

- **`Dockerfile`** — multi-stage standalone build (`node:20-bookworm-slim`, corepack-pinned `pnpm@10.17.1`). `prisma/` is copied before `pnpm install` because `postinstall` runs `prisma generate`. `NODE_OPTIONS=--max-old-space-size=6144` for the build (OOMs at Node's default heap). Server-only required env is satisfied with placeholders at build (same approach as `pre-deployment.yml`); real values come from Dokploy runtime env. Optional vars that arrive as empty build-args are unset before build (t3-env in `src/env.ts` rejects `""` for `.url().optional()`). Deliberately **no strict HEALTHCHECK** — `/api/health` 503s when the DB is degraded and a 2xx-only healthcheck makes Swarm crash-loop (ready-set gotcha); liveness is a Dokploy `healthCheckSwarm` override instead.
- **`.github/workflows/build-and-push.yml`** — multi-arch **without QEMU**: amd64 on `ubuntu-24.04`, arm64 natively on `ubuntu-24.04-arm`, push-by-digest + manifest merge. Tags: `:development` (this branch), `:latest` + short-sha (main). Final step curls the branch-matched Dokploy deploy webhook (self-skips while unset).
- **`.dockerignore`** — keeps the context small, excludes all `.env*` (except example), `.infisical.json`, tests/docs.
- **Env fixes** — `.env.example` now documents `SQUARE_WEBHOOK_SECRET` (the name `src/lib/env/env.ts` actually requires; the old `SQUARE_WEBHOOK_SIGNATURE_KEY` name was listed) plus `SQUARE_WEBHOOK_SECRET_SANDBOX` and `CRON_SECRET` (⚠️ two cron routes skip auth entirely when unset). `CRON_SECRET` added to the Zod schema as optional.

## Verified locally (arm64, matches the Hetzner box)

- Image builds clean; Next 15 standalone output.
- Prisma query engine (`libquery_engine-linux-arm64-openssl-3.0.x`) ships inside the image — no `outputFileTracingIncludes` needed (hoisted node-linker).
- Container boots as non-root, `/` renders 200; `/api/health` responds (503 against a fake DB, as expected).

## Before the workflow can produce a usable image

Repo Actions config needed (values from Vercel prod env / Infisical): Variables `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`, `NEXT_PUBLIC_SENTRY_ENVIRONMENT` (+ optional Umami/Sanity/store vars); Secrets `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `NEXT_PUBLIC_SENTRY_DSN`, optional `BUILD_DATABASE_URL`/`BUILD_DIRECT_URL` (recommended so SSG category pages prerender with real data), `SENTRY_AUTH_TOKEN`, and later the two `DOKPLOY_*_DEPLOY_WEBHOOK` secrets.

Next phases (separate work, per the migration plan): Dokploy apps (dev mirror + prod), schedules for `/api/cron/*`, verification on `preview.destinosf.com`, DNS cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)