### PR TITLE
fix(ci): lowercase GHCR image name

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -46,7 +46,10 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }} # ReadySet1/destino-sf -> ghcr.io/readyset1/destino-sf
+  # Must be lowercase: Docker refs reject "ReadySet1/..." and github.repository
+  # preserves the org's capitalization (metadata-action lowercases, but the
+  # per-arch digest push uses this value directly).
+  IMAGE_NAME: readyset1/destino-sf
 
 jobs:
   build:


### PR DESCRIPTION
One-liner: `IMAGE_NAME` must be lowercase (`readyset1/destino-sf`) — `github.repository` preserves org capitalization and the per-arch digest push in build-and-push.yml consumes it verbatim, so the first image push failed with "repository name must be lowercase". The build itself (with the corrected BUILD_DATABASE_URL secret) completed fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)